### PR TITLE
feat(dc-1): v0.2 docs — Organizations, Roles & Permissions, Magic-link, REST refresh

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -36,6 +36,8 @@ export default defineConfig({
                         { label: 'Embed <SignIn /> in a React app', slug: 'guides/react-sign-in' },
                         { label: 'Verify JWTs in a backend', slug: 'guides/verify-jwt' },
                         { label: 'Verify webhook signatures', slug: 'guides/verify-webhooks' },
+                        { label: 'Organizations', slug: 'guides/organizations' },
+                        { label: 'Magic-link sign-in', slug: 'guides/magic-link' },
                     ],
                 },
                 {
@@ -43,6 +45,7 @@ export default defineConfig({
                     items: [
                         { label: 'REST API', slug: 'reference/rest' },
                         { label: 'SDKs', slug: 'reference/sdks' },
+                        { label: 'Roles & Permissions', slug: 'reference/roles-and-permissions' },
                     ],
                 },
             ],

--- a/src/content/docs/concepts/sessions-and-tokens.md
+++ b/src/content/docs/concepts/sessions-and-tokens.md
@@ -28,8 +28,34 @@ The SDK and the operator Dashboard authenticate via a short-lived JWT minted fro
 | `v`   | Token format version (currently `2`). |
 | `fva` | `[seconds_since_first_factor, seconds_since_second_factor]`. v0.1 always has `-1` for the second factor. |
 | `sts` | `active` or `pending`. |
+| `org` | Active-organization claim — present only when the session has an active org set (v0.2+). See below. |
 
 The default lifetime is intentionally short — the SDK auto-refreshes via `POST /v1/client/sessions/{sid}/tokens` before each request that needs auth.
+
+## Active-organization claim (`org`)
+
+When a member sets an active organization, the session JWT gains an `org` claim:
+
+```json
+{
+  "sub": "user_01K…",
+  "org": {
+    "id": "org_01K…",
+    "slug": "acme",
+    "role": "org:admin",
+    "permissions": [
+      "org:sys_domains:manage",
+      "org:sys_domains:read",
+      "org:sys_memberships:manage",
+      "org:sys_memberships:read",
+      "org:sys_profile:delete",
+      "org:sys_profile:manage"
+    ]
+  }
+}
+```
+
+`org` is absent when no organization is active. Backends must treat its absence as "no org context" — never assume a default. See [Organizations](/guides/organizations/) for how to set the active org, and [Roles & Permissions](/reference/roles-and-permissions/) for the permission catalog.
 
 ## Where the JWT lives
 

--- a/src/content/docs/concepts/webhooks.md
+++ b/src/content/docs/concepts/webhooks.md
@@ -56,17 +56,51 @@ header         = "v1,$signature"
 
 During a rotation window, two `v1,...` segments are sent — verify against either. See [verify webhook signatures](/guides/verify-webhooks/) for code.
 
-## Event types (v0.1)
+## Event types
+
+### v0.1
 
 ```
 user.created
 user.updated
 user.deleted
-email_address.verified
 session.created
 session.ended
-sign_in.failed
-sign_up.completed
+session.removed
+session.revoked
+email.created
+invitation.created
+invitation.accepted
+invitation.revoked
 ```
 
-More land per milestone; the live list is published via `GET /v1/event_types` against the BAPI.
+### v0.2
+
+```
+session.touched
+organization.created
+organization.updated
+organization.deleted
+organizationMembership.created
+organizationMembership.updated
+organizationMembership.deleted
+organizationInvitation.created
+organizationInvitation.accepted
+organizationInvitation.revoked
+organizationDomain.created
+organizationDomain.updated
+organizationDomain.deleted
+organizationMembershipRequest.created
+organizationMembershipRequest.accepted
+organizationMembershipRequest.rejected
+role.created
+role.updated
+role.deleted
+permission.created
+permission.updated
+permission.deleted
+```
+
+The `data` field of each event carries the full resource snapshot — `Organization`, `OrganizationMembership`, `OrganizationInvitation`, `OrganizationDomain`, `OrganizationMembershipRequest`, `Role`, or `Permission` — so handlers don't need a follow-up fetch in most cases. Magic-link sign-in/sign-up does not introduce its own event type; the outgoing email is reported via the existing `email.created` event.
+
+The live list is published via `GET /v1/event_types` against the BAPI.

--- a/src/content/docs/guides/magic-link.md
+++ b/src/content/docs/guides/magic-link.md
@@ -1,0 +1,147 @@
+---
+title: Magic-link sign-in
+description: Passwordless sign-in via a click-through email link, covering same-device and cross-device flows.
+---
+
+The `email_link` strategy sends a one-time link instead of a code. The user clicks it in their email client; authn.sh validates the ticket and completes sign-in. No code to copy — just a click.
+
+## When to use it vs email-code
+
+| | `email_code` | `email_link` |
+| --- | --- | --- |
+| User action | Type 6 digits | Click a link |
+| Works across devices | Yes | Yes (with polling) |
+| Copy-paste friction | Yes | No |
+| Replay protection | Inherent (one-time code) | Signed, expiring ticket |
+
+`email_link` is better for transactional, one-shot sign-in flows where friction is the main concern. `email_code` is better when the user is expected to complete sign-in on the same session tab.
+
+## Same-device flow
+
+The simplest case: the user opens their email on the same device and browser where they started sign-in.
+
+1. Call `prepareFirstFactor` with `strategy: email_link` and a `redirect_url`.
+2. The user receives an email with the magic link.
+3. The link opens in the browser, hitting `GET /v1/client/handshake?__authn_ticket=…&redirect_url=…`.
+4. `clientHandshake` validates the ticket and sets `__client` — the session is now active.
+5. The browser is redirected to `redirect_url`.
+
+```tsx
+import { useSignIn } from '@authn.sh/sdk-react';
+
+function MagicLinkSignIn() {
+    const { signIn, isLoaded } = useSignIn();
+
+    const send = async (email: string) => {
+        await signIn.create({ identifier: email });
+
+        await signIn.prepareFirstFactor({
+            strategy: 'email_link',
+            emailAddressId: signIn.supportedFirstFactors
+                ?.find((f) => f.strategy === 'email_link')
+                ?.emailAddressId ?? '',
+            redirectUrl: `${window.location.origin}/sso-callback`,
+        });
+    };
+
+    if (!isLoaded) return null;
+
+    return (
+        <form onSubmit={(e) => { e.preventDefault(); send(new FormData(e.currentTarget).get('email') as string); }}>
+            <input name="email" type="email" required />
+            <button type="submit">Send magic link</button>
+        </form>
+    );
+}
+```
+
+Mount `<MagicLinkLanding />` at the `redirect_url` path to handle the landing:
+
+```tsx
+import { MagicLinkLanding } from '@authn.sh/sdk-react';
+
+<MagicLinkLanding
+    afterSignInUrl="/dashboard"
+    afterSignUpUrl="/welcome"
+/>;
+```
+
+`<MagicLinkLanding />` reads `__authn_ticket` from the query string, calls `clientHandshake`, and redirects to the appropriate URL once sign-in completes.
+
+## Cross-device flow
+
+The user starts sign-in on a laptop, opens the email on their phone, and clicks the link there. The laptop tab must poll until the click resolves.
+
+authn.sh handles this via the `__client` cookie. The originating device polls `getClient` while the other device completes the handshake:
+
+```tsx
+import { useSignIn } from '@authn.sh/sdk-react';
+
+function MagicLinkSignInWithPolling() {
+    const { signIn } = useSignIn();
+
+    const send = async (email: string) => {
+        await signIn.create({ identifier: email });
+
+        const factor = signIn.supportedFirstFactors?.find(
+            (f) => f.strategy === 'email_link',
+        );
+
+        await signIn.prepareFirstFactor({
+            strategy: 'email_link',
+            emailAddressId: factor?.emailAddressId ?? '',
+            redirectUrl: `${window.location.origin}/sso-callback`,
+        });
+
+        // SDK polls getClient automatically; subscribe to status changes
+        signIn.on('status_change', (status) => {
+            if (status === 'complete') {
+                window.location.href = '/dashboard';
+            }
+        });
+    };
+}
+```
+
+The SDK polls every 2 seconds via `POST /v1/client/sessions/{sid}/tokens` on the originating device. When the other device clicks the link and `clientHandshake` validates the ticket, the session on the originating device transitions to `complete` on the next poll.
+
+The cross-device poll window expires after 10 minutes. If the user hasn't clicked by then, the sign-in must be restarted.
+
+## Transferable flow
+
+If the user who clicks the link has no account, they are transferred to sign-up automatically. `<MagicLinkLanding />` handles this transparently — pass both `afterSignInUrl` and `afterSignUpUrl` and the component routes to the right one.
+
+You can also handle it manually:
+
+```ts
+import { authn } from '@authn.sh/sdk-js';
+
+const signIn = authn.client.signIn;
+const result = await signIn.attemptFirstFactor({ strategy: 'email_link' });
+
+if (result.status === 'needs_transfer') {
+    // Create a sign-up using the email from the sign-in attempt
+    const signUp = await authn.client.signUp.create({
+        transfer: true,
+    });
+    // continue sign-up flow
+}
+```
+
+## Replay protection
+
+Every magic-link ticket is:
+
+- **Single-use** — consumed on the first valid `clientHandshake` call.
+- **Time-limited** — expires after 10 minutes (same as the cross-device poll window).
+- **Bound to the environment** — tickets signed by one FAPI URL are rejected by others.
+
+Replaying the link after it's been used returns `422 magic_link_expired`.
+
+## REST reference
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/v1/client/sign_ins/{sign_in_id}/prepare_first_factor` | Prepare `email_link` factor — sends the email. |
+| `POST` | `/v1/client/sign_ins/{sign_in_id}/attempt_first_factor` | Poll / attempt `email_link` on the originating device. |
+| `GET`  | `/v1/client/handshake` | Consume a `__authn_ticket` and complete the session. |

--- a/src/content/docs/guides/organizations.md
+++ b/src/content/docs/guides/organizations.md
@@ -1,0 +1,239 @@
+---
+title: Organizations
+description: Group users into organizations, manage roles and invitations, and gate access by membership.
+---
+
+An **Organization** is a shared tenant within your environment — a named entity that groups users via memberships, carries its own roles and verified domains, and injects an `org` claim into session JWTs when a member makes it their active organization.
+
+Use organizations when your product is multi-tenant and users belong to accounts they didn't personally create (teams, companies, projects, etc.). Single-user products don't need them.
+
+## Create an organization
+
+### Via BAPI (server-side)
+
+```bash
+curl -X POST https://<FAPI_URL>/v1/organizations \
+  -H "Authorization: Bearer <secret_key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Acme Inc.",
+    "slug": "acme",
+    "created_by": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB"
+  }'
+```
+
+```php
+use AuthnSh\Sdk\Authn;
+
+$org = Authn::organizations()->create([
+    'name'       => 'Acme Inc.',
+    'slug'       => 'acme',
+    'created_by' => $user->authn_id,
+]);
+```
+
+The `created_by` user is automatically added as a member with the `org:admin` role (`is_creator_eligible: true`).
+
+### Via SDK (client-side, React)
+
+```tsx
+import { useOrganizationActions } from '@authn.sh/sdk-react';
+
+function CreateOrgButton() {
+    const { createOrganization } = useOrganizationActions();
+
+    return (
+        <button
+            onClick={() =>
+                createOrganization({ name: 'Acme Inc.', slug: 'acme' })
+            }
+        >
+            Create organization
+        </button>
+    );
+}
+```
+
+Or drop in the pre-built form:
+
+```tsx
+import { CreateOrganization } from '@authn.sh/sdk-react';
+
+<CreateOrganization afterCreateOrganizationUrl="/dashboard" />;
+```
+
+### Via Account Portal
+
+Signed-in users can create organizations from their Account Portal at `/user` → **Organizations** — no additional code needed if `<UserProfile />` is mounted.
+
+## Invite members
+
+Members are invited by email. An invitation email is sent; clicking the link takes the recipient through sign-up (or sign-in if they already have an account) and then adds them as a member.
+
+```bash
+curl -X POST https://<FAPI_URL>/v1/organizations/org_01K.../invitations \
+  -H "Authorization: Bearer <secret_key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email_address": "kate@acme.com",
+    "role": "org:member",
+    "redirect_url": "https://app.acme.com/welcome"
+  }'
+```
+
+```php
+Authn::organizationInvitations($orgId)->create([
+    'email_address' => 'kate@acme.com',
+    'role'          => 'org:member',
+    'redirect_url'  => 'https://app.acme.com/welcome',
+]);
+```
+
+```tsx
+import { useOrganizationActions } from '@authn.sh/sdk-react';
+
+const { inviteMember } = useOrganizationActions();
+
+await inviteMember({
+    emailAddress: 'kate@acme.com',
+    role: 'org:member',
+});
+```
+
+Invitations expire after 30 days. Revoke early with `DELETE /v1/organizations/{org_id}/invitations/{inv_id}/revoke`.
+
+## Manage roles
+
+Each member holds exactly one role. Change it with a `PATCH` on the membership:
+
+```bash
+curl -X PATCH https://<FAPI_URL>/v1/organizations/org_01K.../memberships/orgmem_01K... \
+  -H "Authorization: Bearer <secret_key>" \
+  -H "Content-Type: application/json" \
+  -d '{ "role": "org:admin" }'
+```
+
+```php
+Authn::organizationMemberships($orgId)->update($membershipId, [
+    'role' => 'org:admin',
+]);
+```
+
+```tsx
+import { useOrganizationActions } from '@authn.sh/sdk-react';
+
+const { updateMemberRole } = useOrganizationActions();
+
+await updateMemberRole(membershipId, 'org:admin');
+```
+
+The caller must hold `org:sys_memberships:manage` in the same organization to change another member's role.
+
+## Active organization
+
+A session has at most one **active organization** at a time — the one the user is currently operating as. Setting it embeds an `org` claim in the session JWT:
+
+```json
+{
+  "sub": "user_01K…",
+  "org": {
+    "id": "org_01K…",
+    "slug": "acme",
+    "role": "org:admin",
+    "permissions": [
+      "org:sys_memberships:manage",
+      "org:sys_memberships:read",
+      "org:sys_profile:delete",
+      "org:sys_profile:manage",
+      "org:sys_domains:manage",
+      "org:sys_domains:read"
+    ]
+  }
+}
+```
+
+The SDK sets the active org automatically when the user switches organizations.
+
+```tsx
+import { useActiveOrganization, useOrganizationList } from '@authn.sh/sdk-react';
+
+function OrgSwitcher() {
+    const { organization } = useActiveOrganization();
+    const { setActive, organizationList } = useOrganizationList();
+
+    return (
+        <select
+            value={organization?.id ?? ''}
+            onChange={(e) => setActive({ organization: e.target.value })}
+        >
+            {organizationList.map((org) => (
+                <option key={org.id} value={org.id}>
+                    {org.name}
+                </option>
+            ))}
+        </select>
+    );
+}
+```
+
+Or use the pre-built component:
+
+```tsx
+import { OrganizationSwitcher } from '@authn.sh/sdk-react';
+
+<OrganizationSwitcher />;
+```
+
+On the backend, read the active org from the verified JWT. See [Verify JWTs in a backend](/guides/verify-jwt/) for setup, then:
+
+```php
+use AuthnSh\Sdk\Authn;
+
+$claims = Authn::verifyToken($jwt);
+
+// $claims->organization is populated only when a member is active in an org
+if ($claims->organization?->hasPermission('org:sys_memberships:manage')) {
+    // allow
+}
+```
+
+See [Roles & Permissions](/reference/roles-and-permissions/) for the full permission catalog.
+
+## Domain enrollment
+
+Verified domains let you automate membership based on a user's email domain. Once a domain is verified, one of three enrollment modes applies to new sign-ups:
+
+| Mode | Effect |
+| ---- | ------ |
+| `manual_invitation` | No automatic action — members must be invited explicitly (the default). |
+| `automatic_invitation` | Sign-ups whose email matches the domain skip the invitation step and join immediately as the `default_role`. |
+| `automatic_suggestion` | Sign-ups with a matching email receive an `OrganizationMembershipRequest` that an admin must approve. |
+
+### Add a domain
+
+```bash
+curl -X POST https://<FAPI_URL>/v1/organizations/org_01K.../domains \
+  -H "Authorization: Bearer <secret_key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "acme.com",
+    "enrollment_mode": "automatic_invitation"
+  }'
+```
+
+```php
+Authn::organizationDomains($orgId)->create([
+    'name'            => 'acme.com',
+    'enrollment_mode' => 'automatic_invitation',
+]);
+```
+
+### Verify the domain
+
+Verification proves domain ownership. Two strategies are supported:
+
+**DNS TXT** — add a TXT record with the value from `verification.nonce` to your DNS zone, then call `POST /v1/organizations/{org_id}/domains/{domain_id}/verify`.
+
+**Email code** — an affiliation address at the domain (`admin@acme.com`) receives a 6-digit code; submit it to `POST /v1/organizations/{org_id}/domains/{domain_id}/verify` with `{ "code": "…" }`.
+
+Once `verified: true`, the enrollment mode takes effect for future sign-ups.

--- a/src/content/docs/reference/rest.md
+++ b/src/content/docs/reference/rest.md
@@ -3,9 +3,7 @@ title: REST API reference
 description: Full BAPI + FAPI reference, generated from the OpenAPI spec.
 ---
 
-The REST reference is generated from the [`authn-sh/openapi`](https://github.com/authn-sh/openapi) bundled spec. As of right now the openapi repo is still being scaffolded — once OA-1 lands the build pipeline pulls `openapi.bundled.json` from its tagged release and renders the full reference here.
-
-In the meantime:
+The REST reference is generated from the [`authn-sh/openapi`](https://github.com/authn-sh/openapi) bundled spec. The build pipeline pulls `openapi.bundled.json` from its tagged release and renders the full reference here.
 
 - **Backend API (BAPI)** — server-to-server, secret-key authenticated. Source: [`routes/bapi.php`](https://github.com/authn-sh/authn/blob/main/authn/routes/bapi.php).
 - **Frontend API (FAPI)** — browser-facing, publishable-key + Client-cookie authenticated. Source: [`routes/fapi.php`](https://github.com/authn-sh/authn/blob/main/authn/routes/fapi.php).
@@ -14,6 +12,67 @@ In the meantime:
 ## Conventions
 
 - All timestamps are Unix milliseconds (numbers, not strings).
-- All IDs are prefixed ULIDs — `user_…`, `sess_…`, `evt_…`. Treat as opaque strings.
+- All IDs are prefixed ULIDs — `user_…`, `sess_…`, `org_…`, `evt_…`. Treat as opaque strings.
 - Errors follow the envelope `{ "errors": [{ "code", "message", "long_message", "meta" }], "trace_id" }`.
 - Pagination is opaque cursor-based: `?cursor=<token>&limit=<n>`. Responses include `meta.next_cursor` when more rows exist.
+
+## v0.2 endpoints (BAPI)
+
+### Organizations
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/v1/organizations` | List organizations (cursor-paginated). |
+| `POST` | `/v1/organizations` | Create an organization. |
+| `GET` | `/v1/organizations/{id}` | Get a single organization. |
+| `PATCH` | `/v1/organizations/{id}` | Update name, slug, image, metadata. |
+| `DELETE` | `/v1/organizations/{id}` | Delete an organization. |
+| `GET` | `/v1/organizations/{id}/memberships` | List members. |
+| `POST` | `/v1/organizations/{id}/memberships` | Add a member directly. |
+| `PATCH` | `/v1/organizations/{id}/memberships/{membership_id}` | Change a member's role. |
+| `DELETE` | `/v1/organizations/{id}/memberships/{membership_id}` | Remove a member. |
+| `GET` | `/v1/organizations/{id}/invitations` | List invitations. |
+| `POST` | `/v1/organizations/{id}/invitations` | Create an invitation. |
+| `POST` | `/v1/organizations/{id}/invitations/bulk` | Bulk-create invitations. |
+| `POST` | `/v1/organizations/{id}/invitations/{inv_id}/revoke` | Revoke a pending invitation. |
+| `GET` | `/v1/organizations/{id}/domains` | List verified domains. |
+| `POST` | `/v1/organizations/{id}/domains` | Add a domain. |
+| `PATCH` | `/v1/organizations/{id}/domains/{domain_id}` | Update enrollment mode. |
+| `DELETE` | `/v1/organizations/{id}/domains/{domain_id}` | Remove a domain. |
+| `POST` | `/v1/organizations/{id}/domains/{domain_id}/verify` | Submit verification proof. |
+
+### Roles & Permissions
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/v1/roles` | List roles. |
+| `POST` | `/v1/roles` | Create a custom role. |
+| `GET` | `/v1/roles/{id}` | Get a single role. |
+| `PATCH` | `/v1/roles/{id}` | Update a role's name / description / flags. |
+| `DELETE` | `/v1/roles/{id}` | Delete a custom role. |
+| `PUT` | `/v1/roles/{id}/permissions` | Replace a role's permission set. |
+| `GET` | `/v1/permissions` | List permissions (system + custom). |
+
+## v0.2 endpoints (FAPI)
+
+### User-scoped organization access
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/v1/me/organization_memberships` | List the signed-in user's memberships. |
+| `GET` | `/v1/me/organization_invitations` | List the user's pending invitations. |
+| `POST` | `/v1/me/organization_invitations/{inv_id}/accept` | Accept an invitation. |
+| `GET` | `/v1/me/organization_membership_requests` | List the user's membership requests. |
+| `GET` | `/v1/organizations/{id}` | Get an org the user is a member of. |
+| `GET` | `/v1/organizations/{id}/memberships` | List an org's members (user-scoped). |
+| `POST` | `/v1/organizations/{id}/invitations` | Invite a member (requires `org:sys_memberships:manage`). |
+| `POST` | `/v1/organizations/{id}/leave` | Leave an organization. |
+| `PATCH` | `/v1/client/sessions/{sid}/active_organization` | Set the active organization. |
+
+### Magic-link
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/v1/client/sign_ins/{sign_in_id}/prepare_first_factor` | Prepare `email_link` — sends the magic-link email. |
+| `POST` | `/v1/client/sign_ins/{sign_in_id}/attempt_first_factor` | Poll / complete on originating device. |
+| `GET` | `/v1/client/handshake` | Consume a `__authn_ticket` from the clicked link. |

--- a/src/content/docs/reference/roles-and-permissions.md
+++ b/src/content/docs/reference/roles-and-permissions.md
@@ -1,0 +1,149 @@
+---
+title: Roles & Permissions
+description: System permission catalog, default roles, and per-platform helpers for checking org access.
+---
+
+Every environment is seeded with two roles and 13 system permissions at bootstrap. Custom roles and permissions can be added via BAPI (custom permissions land in v0.3+).
+
+## Default roles
+
+| `key` | `is_creator_eligible` | `is_default` | Permissions |
+| ----- | :-------------------: | :----------: | ----------- |
+| `org:admin` | yes | no | All 13 system permissions. |
+| `org:member` | no | yes | The `:read` subset — `org:sys_profile:read`, `org:sys_memberships:read`, `org:sys_domains:read`, `org:sys_billing:read`, `org:sys_sso:read`, `org:sys_provisioning:read`. |
+
+`is_creator_eligible` — the organization creator is assigned the first eligible role. `org:admin` is the only eligible role in the default seed.
+
+`is_default` — new members enrolled via `automatic_invitation` or accepted `OrganizationMembershipRequest` receive the default role. `org:member` is the default out of the box.
+
+## System permissions catalog
+
+All 13 system permissions are seeded with `is_system: true`. They cannot be deleted; their `name` field may be localized.
+
+| `key` | Purpose |
+| ----- | ------- |
+| `org:sys_profile:read` | Read org name, slug, image. |
+| `org:sys_profile:manage` | Edit org name, slug, image, and metadata. |
+| `org:sys_profile:delete` | Delete the org (subject to `admin_delete_enabled`). |
+| `org:sys_memberships:read` | List members and pending requests. |
+| `org:sys_memberships:manage` | Invite, remove, change roles, accept membership requests. |
+| `org:sys_domains:read` | List verified domains. |
+| `org:sys_domains:manage` | Add, verify, change enrollment mode, delete domains. |
+| `org:sys_billing:read` | Reserved — billing milestone. |
+| `org:sys_billing:manage` | Reserved — billing milestone. |
+| `org:sys_sso:read` | Reserved — v0.6 enterprise SSO. |
+| `org:sys_sso:manage` | Reserved — v0.6 enterprise SSO. |
+| `org:sys_provisioning:read` | Reserved — v0.6 SCIM. |
+| `org:sys_provisioning:manage` | Reserved — v0.6 SCIM. |
+
+The billing, SSO, and provisioning permissions are seeded now so that default roles can declare them, enabling downstream milestones to wire up endpoints without a fresh seed.
+
+## Create a custom role
+
+Custom roles are scoped to an environment and shared across all its organizations.
+
+```bash
+curl -X POST https://<FAPI_URL>/v1/roles \
+  -H "Authorization: Bearer <secret_key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "org:billing",
+    "name": "Billing manager",
+    "permissions": ["org:sys_billing:read", "org:sys_billing:manage"]
+  }'
+```
+
+```php
+use AuthnSh\Sdk\Authn;
+
+Authn::roles()->create([
+    'key'         => 'org:billing',
+    'name'        => 'Billing manager',
+    'permissions' => ['org:sys_billing:read', 'org:sys_billing:manage'],
+]);
+```
+
+Role keys must match `^org:[a-z][a-z0-9_]*$` and must not collide with `org:admin`, `org:member`, or the `org:sys_*` permission prefix.
+
+To replace a role's permission set wholesale:
+
+```bash
+curl -X PUT https://<FAPI_URL>/v1/roles/<role_id>/permissions \
+  -H "Authorization: Bearer <secret_key>" \
+  -H "Content-Type: application/json" \
+  -d '{ "permissions": ["org:sys_billing:read"] }'
+```
+
+Sending `[]` clears all permissions.
+
+## Checking permissions
+
+### PHP backend (`sdk-php`)
+
+```php
+use AuthnSh\Sdk\Authn;
+
+$claims = Authn::verifyToken($jwt);
+
+// Check permission from the active-org claim
+if ($claims->organization?->hasPermission('org:sys_memberships:manage')) {
+    // caller may manage memberships
+}
+
+// Or check via the manager (server-to-server)
+$membership = Authn::organizationMemberships($orgId)->get($membershipId);
+$canManage = in_array('org:sys_memberships:manage', $membership->permissions, true);
+```
+
+### Laravel (`sdk-php-laravel`)
+
+```blade
+@authnHas('permission:org:sys_memberships:manage')
+    <a href="/members/manage">Manage members</a>
+@endAuthnHas
+
+@authnHas('role:org:admin')
+    <a href="/settings/delete">Delete organization</a>
+@endAuthnHas
+```
+
+```php
+use AuthnSh\Laravel\Facades\Authn;
+
+if (Authn::hasPermission('org:sys_memberships:manage')) {
+    // allow
+}
+
+if (Authn::hasRole('org:admin')) {
+    // allow
+}
+```
+
+Both helpers read from the active-org claim in the current request's JWT.
+
+### React (`sdk-react`)
+
+```tsx
+import { useOrganization } from '@authn.sh/sdk-react';
+
+function ManageMembersButton() {
+    const { membership } = useOrganization();
+
+    if (!membership?.hasPermission('org:sys_memberships:manage')) {
+        return null;
+    }
+
+    return <button>Manage members</button>;
+}
+```
+
+`membership.hasPermission(key)` checks against the computed `permissions[]` on the membership returned by the SDK — no extra request needed.
+
+### SDK-JS (vanilla)
+
+```ts
+import { authn } from '@authn.sh/sdk-js';
+
+const membership = authn.organization?.membership;
+const canManage = membership?.hasPermission('org:sys_memberships:manage') ?? false;
+```


### PR DESCRIPTION
## Summary

- **New: Guides → Organizations** — org creation via BAPI/SDK/Account Portal, member invitations, role management, active-organization concept + JWT `org` claim, domain enrollment modes (manual / automatic_invitation / automatic_suggestion) + DNS verification.
- **New: Reference → Roles & Permissions** — 13 system permission keys, two seeded default roles (`org:admin` / `org:member`), custom role creation via BAPI, per-platform permission helpers (PHP / Laravel / React / sdk-js).
- **New: Guides → Magic-link sign-in** — `email_link` strategy, same-device flow, cross-device `__client` polling, transferable sign-in→sign-up, replay protection, REST table.
- **REST reference refresh** — updated v0.2 BAPI + FAPI endpoint tables (organizations, memberships, invitations, domains, roles, permissions, magic-link).
- **Cross-links** — Sessions page gains the `org` JWT claim section; Webhooks page gains the full v0.2 event catalog.

## Test plan

- [x] `npm run build` exits 0; all 16 pages generated cleanly.
- [x] New sidebar entries (`guides/organizations`, `guides/magic-link`, `reference/roles-and-permissions`) resolve correctly in the build output.
- [x] No broken internal links in new pages (all slugs verified against actual file paths).