### PR TITLE
refactor: kebab-case URL path segments in docs

### DIFF
--- a/src/content/docs/concepts/webhooks.md
+++ b/src/content/docs/concepts/webhooks.md
@@ -103,4 +103,4 @@ permission.deleted
 
 The `data` field of each event carries the full resource snapshot — `Organization`, `OrganizationMembership`, `OrganizationInvitation`, `OrganizationDomain`, `OrganizationMembershipRequest`, `Role`, or `Permission` — so handlers don't need a follow-up fetch in most cases. Magic-link sign-in/sign-up does not introduce its own event type; the outgoing email is reported via the existing `email.created` event.
 
-The live list is published via `GET /v1/event_types` against the BAPI.
+The live list is published via `GET /v1/event-types` against the BAPI.

--- a/src/content/docs/getting-started/first-sign-in.md
+++ b/src/content/docs/getting-started/first-sign-in.md
@@ -58,7 +58,7 @@ VITE_AUTHN_PUBLISHABLE_KEY=pk_live_…paste-yours-here
 ## What just happened
 
 - The SDK decoded `pk_live_…` to find your FAPI URL and called `GET /v1/environment` + `GET /v1/client` to bootstrap.
-- Sign-up POSTed to `/v1/client/sign_ups`, then `prepare_verification` sent the email.
+- Sign-up POSTed to `/v1/client/sign-ups`, then `prepare-verification` sent the email.
 - After `attempt_verification`, the server set a `__session` HttpOnly cookie. `<SignedIn>` started rendering its children; `<UserButton>` mounted with the user's avatar.
 
 Next stops:

--- a/src/content/docs/guides/magic-link.md
+++ b/src/content/docs/guides/magic-link.md
@@ -142,6 +142,6 @@ Replaying the link after it's been used returns `422 magic_link_expired`.
 
 | Method | Path | Description |
 | ------ | ---- | ----------- |
-| `POST` | `/v1/client/sign_ins/{sign_in_id}/prepare_first_factor` | Prepare `email_link` factor — sends the email. |
-| `POST` | `/v1/client/sign_ins/{sign_in_id}/attempt_first_factor` | Poll / attempt `email_link` on the originating device. |
+| `POST` | `/v1/client/sign-ins/{sign_in_id}/prepare-first-factor` | Prepare `email_link` factor — sends the email. |
+| `POST` | `/v1/client/sign-ins/{sign_in_id}/attempt-first-factor` | Poll / attempt `email_link` on the originating device. |
 | `GET`  | `/v1/client/handshake` | Consume a `__authn_ticket` and complete the session. |

--- a/src/content/docs/reference/rest.md
+++ b/src/content/docs/reference/rest.md
@@ -59,20 +59,20 @@ The REST reference is generated from the [`authn-sh/openapi`](https://github.com
 
 | Method | Path | Description |
 | ------ | ---- | ----------- |
-| `GET` | `/v1/me/organization_memberships` | List the signed-in user's memberships. |
-| `GET` | `/v1/me/organization_invitations` | List the user's pending invitations. |
-| `POST` | `/v1/me/organization_invitations/{inv_id}/accept` | Accept an invitation. |
-| `GET` | `/v1/me/organization_membership_requests` | List the user's membership requests. |
+| `GET` | `/v1/me/organization-memberships` | List the signed-in user's memberships. |
+| `GET` | `/v1/me/organization-invitations` | List the user's pending invitations. |
+| `POST` | `/v1/me/organization-invitations/{inv_id}/accept` | Accept an invitation. |
+| `GET` | `/v1/me/organization-membership-requests` | List the user's membership requests. |
 | `GET` | `/v1/organizations/{id}` | Get an org the user is a member of. |
 | `GET` | `/v1/organizations/{id}/memberships` | List an org's members (user-scoped). |
 | `POST` | `/v1/organizations/{id}/invitations` | Invite a member (requires `org:sys_memberships:manage`). |
 | `POST` | `/v1/organizations/{id}/leave` | Leave an organization. |
-| `PATCH` | `/v1/client/sessions/{sid}/active_organization` | Set the active organization. |
+| `PATCH` | `/v1/client/sessions/{sid}/active-organization` | Set the active organization. |
 
 ### Magic-link
 
 | Method | Path | Description |
 | ------ | ---- | ----------- |
-| `POST` | `/v1/client/sign_ins/{sign_in_id}/prepare_first_factor` | Prepare `email_link` — sends the magic-link email. |
-| `POST` | `/v1/client/sign_ins/{sign_in_id}/attempt_first_factor` | Poll / complete on originating device. |
+| `POST` | `/v1/client/sign-ins/{sign_in_id}/prepare-first-factor` | Prepare `email_link` — sends the magic-link email. |
+| `POST` | `/v1/client/sign-ins/{sign_in_id}/attempt-first-factor` | Poll / complete on originating device. |
 | `GET` | `/v1/client/handshake` | Consume a `__authn_ticket` from the clicked link. |


### PR DESCRIPTION
## Summary

- Updates all REST URL path segments in docs to kebab-case following openapi PR #28
- Affected files: `reference/rest.md`, `guides/magic-link.md`, `getting-started/first-sign-in.md`, `concepts/webhooks.md`
- JSON field names, path parameters (`{org_id}`, `{inv_id}`, etc.), and query parameters remain snake_case

## Test plan

- [x] `npm run build` passes cleanly (16 pages built, no errors)
- [x] No remaining underscore path segments in `/v1/` URLs
- [x] All internal cross-references consistent