### PR TITLE
docs: update guides for generalized Challenge resource

### DIFF
--- a/src/content/docs/guides/magic-link.md
+++ b/src/content/docs/guides/magic-link.md
@@ -122,6 +122,28 @@ challenge.on('status_change', async (status) => {
 });
 ```
 
+## Verifying additional emails
+
+The same `email_link` strategy works when a signed-in user adds a secondary email address and needs to verify ownership. The flow is identical to sign-in's magic-link path — only the parent resource changes from `sign-in` to `email-address`.
+
+```ts
+import { authn } from '@authn.sh/sdk-js';
+
+const emailAddress = authn.user.emailAddresses.find(e => e.id === targetId);
+
+const challenge = await emailAddress.createChallenge({ strategy: 'email_link' });
+
+await challenge.answer({});
+
+challenge.on('status_change', (status) => {
+    if (status === 'verified') {
+        console.log('email verified');
+    }
+});
+```
+
+The SDK polls `GET /v1/me/email-addresses/{id}/challenges/{cid}` until `status` flips to `verified`. The same 10-minute expiry applies.
+
 ## Replay protection
 
 Every magic-link ticket is:
@@ -140,3 +162,6 @@ Replaying the link after it's been used returns `422 magic_link_expired`.
 | `POST` | `/v1/client/sign-ins/{sid}/challenges/{cid}/answer` | Commit to polling (empty body for `email_link`). |
 | `GET`  | `/v1/client/sign-ins/{sid}/challenges/{cid}` | Poll challenge status on the originating device. |
 | `GET`  | `/v1/client/handshake` | Consume a `__authn_ticket` and complete the session. |
+| `POST` | `/v1/me/email-addresses/{id}/challenges` | Issue an `email_link` or `email_code` challenge for a secondary email. |
+| `POST` | `/v1/me/email-addresses/{id}/challenges/{cid}/answer` | Answer the challenge (code string or empty body for `email_link`). |
+| `GET`  | `/v1/me/email-addresses/{id}/challenges/{cid}` | Poll verification status. |

--- a/src/content/docs/guides/organizations.md
+++ b/src/content/docs/guides/organizations.md
@@ -230,10 +230,57 @@ Authn::organizationDomains($orgId)->create([
 
 ### Verify the domain
 
-Verification proves domain ownership. Two strategies are supported:
+Verification proves domain ownership via a `Challenge` resource. Two strategies are supported:
 
-**DNS TXT** — add a TXT record with the value from `verification.nonce` to your DNS zone, then call `POST /v1/organizations/{org_id}/domains/{domain_id}/verify`.
+**DNS TXT** — the server creates a challenge and returns a `nonce` — the TXT value you must publish in your DNS zone. Your operator publishes the record, then polls `GET /v1/organizations/{org_id}/domains/{domain_id}/challenges/{cid}` until `status: verified`. There is no separate verify call; authn.sh resolves the record on the next poll and flips the status automatically.
 
-**Email code** — an affiliation address at the domain (`admin@acme.com`) receives a 6-digit code; submit it to `POST /v1/organizations/{org_id}/domains/{domain_id}/verify` with `{ "code": "…" }`.
+```bash
+curl -X POST https://<FAPI_URL>/v1/organizations/org_01K.../domains/orgdom_01K.../challenges \
+  -H "Authorization: Bearer <secret_key>" \
+  -H "Content-Type: application/json" \
+  -d '{ "strategy": "dns_txt" }'
+```
+
+The response includes:
+
+```json
+{
+  "id": "cha_01K...",
+  "strategy": "dns_txt",
+  "nonce": "_authn-domain-verify.acme.com TXT \"authn_<nonce>\"",
+  "status": "pending"
+}
+```
+
+Publish the TXT record, then poll:
+
+```bash
+curl https://<FAPI_URL>/v1/organizations/org_01K.../domains/orgdom_01K.../challenges/cha_01K... \
+  -H "Authorization: Bearer <secret_key>"
+```
+
+When the record resolves, `status` flips to `verified` and `OrganizationDomain.verified` becomes `true`. The polling approach is an improvement over a one-shot verify call — your operator can publish the record asynchronously and let the API confirm ownership without a synchronous HTTP round-trip.
+
+**Email code** — an affiliation address at the domain (`admin@acme.com`) receives a 6-digit code. Create a challenge with `strategy: email_code`, then answer it with the code:
+
+```bash
+curl -X POST https://<FAPI_URL>/v1/organizations/org_01K.../domains/orgdom_01K.../challenges \
+  -H "Authorization: Bearer <secret_key>" \
+  -H "Content-Type: application/json" \
+  -d '{ "strategy": "email_code" }'
+
+curl -X POST https://<FAPI_URL>/v1/organizations/org_01K.../domains/orgdom_01K.../challenges/cha_01K.../answer \
+  -H "Authorization: Bearer <secret_key>" \
+  -H "Content-Type: application/json" \
+  -d '{ "code": "123456" }'
+```
+
+```php
+$challenge = Authn::organizationDomainChallenges($orgId, $domainId)->create([
+    'strategy' => 'email_code',
+]);
+
+$challenge->answer(['code' => $request->input('code')]);
+```
 
 Once `verified: true`, the enrollment mode takes effect for future sign-ups.

--- a/src/content/docs/guides/react-sign-in.md
+++ b/src/content/docs/guides/react-sign-in.md
@@ -45,3 +45,37 @@ Default is `path`. `virtual` is what the bundled Account Portal uses.
 - `<RedirectToSignIn>` — kicks signed-out visitors to your sign-in URL.
 
 A worked tenant integration ships in v0.1.x; for now, the [Account Portal source](https://github.com/authn-sh/authn/tree/main/resources/js/account-portal) is the canonical example.
+
+## Adding and verifying email addresses
+
+When a user adds a secondary email via `<UserProfile />` or your own form, the new address starts unverified. Verification is a `Challenge` on the `EmailAddress` resource — the same pattern used for sign-in verification.
+
+Both `email_code` and `email_link` strategies are available:
+
+```ts
+import { useUser } from '@authn.sh/sdk-react';
+
+const { user } = useUser();
+
+const emailAddress = user.emailAddresses.find(e => e.id === targetId);
+
+const challenge = await emailAddress.createChallenge({ strategy: 'email_code' });
+
+await challenge.answer({ code: userInput });
+```
+
+For `email_link`, omit the code and poll instead:
+
+```ts
+const challenge = await emailAddress.createChallenge({ strategy: 'email_link' });
+
+await challenge.answer({});
+
+challenge.on('status_change', (status) => {
+    if (status === 'verified') {
+        console.log('email verified');
+    }
+});
+```
+
+Once the challenge reaches `status: verified`, `EmailAddress.verified` flips to `true` and `current_challenge_id` clears to `null`. `<UserProfile />` handles this automatically — no custom code needed if you're using the component.

--- a/src/content/docs/reference/rest.md
+++ b/src/content/docs/reference/rest.md
@@ -39,7 +39,9 @@ The REST reference is generated from the [`authn-sh/openapi`](https://github.com
 | `POST` | `/v1/organizations/{id}/domains` | Add a domain. |
 | `PATCH` | `/v1/organizations/{id}/domains/{domain_id}` | Update enrollment mode. |
 | `DELETE` | `/v1/organizations/{id}/domains/{domain_id}` | Remove a domain. |
-| `POST` | `/v1/organizations/{id}/domains/{domain_id}/verify` | Submit verification proof. |
+| `POST` | `/v1/organizations/{id}/domains/{domain_id}/challenges` | Create a domain-verification challenge (`dns_txt` or `email_code`). |
+| `POST` | `/v1/organizations/{id}/domains/{domain_id}/challenges/{cid}/answer` | Submit the email code to answer a challenge. |
+| `GET`  | `/v1/organizations/{id}/domains/{domain_id}/challenges/{cid}` | Poll challenge status (`dns_txt` resolves automatically on poll). |
 
 ### Roles & Permissions
 
@@ -68,6 +70,14 @@ The REST reference is generated from the [`authn-sh/openapi`](https://github.com
 | `POST` | `/v1/organizations/{id}/invitations` | Invite a member (requires `org:sys_memberships:manage`). |
 | `POST` | `/v1/organizations/{id}/leave` | Leave an organization. |
 | `PATCH` | `/v1/client/sessions/{sid}/active-organization` | Set the active organization. |
+
+### Email address verification
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/v1/me/email-addresses/{id}/challenges` | Issue an `email_code` or `email_link` verification challenge. |
+| `POST` | `/v1/me/email-addresses/{id}/challenges/{cid}/answer` | Answer a challenge (code string, or empty body for `email_link`). |
+| `GET`  | `/v1/me/email-addresses/{id}/challenges/{cid}` | Poll challenge status. |
 
 ### Challenges (sign-in)
 


### PR DESCRIPTION
## Summary

- **Magic-link guide** — adds a "Verifying additional emails" subsection showing the `email_address` Challenge flow (create + poll) alongside the sign-in flow
- **Organizations guide** — replaces the one-shot `POST /domains/{id}/verify` pattern with Challenge-based DNS TXT (polling) and `email_code` (answer) flows; calls out the UX improvement of async polling vs a synchronous verify round-trip
- **React sign-in guide** — adds an "Adding and verifying email addresses" section covering both `email_code` and `email_link` strategies via `EmailAddress.createChallenge`
- **REST reference** — drops `POST /domains/{id}/verify`; adds challenge CRUD for both `email-addresses` (FAPI) and `organization domains` (BAPI); removes `prepareMyEmailVerification` / `verifyOrganizationDomain` patterns

## Test plan

- [x] `npm run build` passes cleanly (16 pages, 0 errors)
- [ ] CI green
- [ ] Spot-check rendered pages for /guides/magic-link, /guides/organizations, /guides/react-sign-in, /reference/rest