### PR TITLE
docs(v0.3): MFA guides and security components reference

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -50,6 +50,8 @@ export default defineConfig({
                         { label: 'Verify webhook signatures', slug: 'guides/verify-webhooks' },
                         { label: 'Organizations', slug: 'guides/organizations' },
                         { label: 'Magic-link sign-in', slug: 'guides/magic-link' },
+                        { label: 'Multi-factor authentication', slug: 'guides/multi-factor-authentication' },
+                        { label: 'Second-factor sign-in', slug: 'guides/second-factor-sign-in' },
                     ],
                 },
                 {
@@ -58,6 +60,7 @@ export default defineConfig({
                         { label: 'REST API', slug: 'reference/rest' },
                         { label: 'SDKs', slug: 'reference/sdks' },
                         { label: 'Roles & Permissions', slug: 'reference/roles-and-permissions' },
+                        { label: 'Security section components', slug: 'reference/security-components' },
                     ],
                 },
             ],

--- a/src/content/docs/guides/multi-factor-authentication.md
+++ b/src/content/docs/guides/multi-factor-authentication.md
@@ -1,0 +1,176 @@
+---
+title: Multi-factor authentication
+description: Enable TOTP and backup codes for your users — enrollment, management, and operator controls.
+---
+
+Multi-factor authentication (MFA) adds a second proof of identity to sign-in. authn.sh supports two second factors: **TOTP** (time-based one-time passwords, via any authenticator app) and **backup codes** (single-use recovery codes).
+
+Both factors are enabled by default. Toggle them per-environment under **Dashboard → Configure → Security → Multi-factor authentication**, or via the BAPI `PATCH /v1/instance` body's `multi_factor` block.
+
+## When to require MFA
+
+MFA makes the most sense for:
+
+- Applications with sensitive data or elevated-privilege accounts.
+- B2B products where a customer's security policy mandates it.
+- Environments where phishing a password is a realistic threat.
+
+MFA is opt-in per user by default. If your product requires it for all users, gate access in your backend after verifying the JWT — check `two_factor_enabled` on the `User` claim — and redirect users without a second factor to the enrollment surface before letting them in.
+
+## TOTP enrollment
+
+Enrollment is a three-step dance: mint a secret, let the user scan the QR code and add it to their authenticator app, then confirm with the first generated code.
+
+### Step 1 — Start enrollment
+
+```http
+POST /v1/me/totp
+```
+
+Returns a `TotpSecret` with `secret` (base32), `otpauth_uri`, and `qr_code_data_url`. These fields are only returned here — once verified, the server clears them and they can never be retrieved again.
+
+If the user already has an **unverified** TOTP secret (started enrollment but never confirmed), calling this endpoint again overwrites the row with a fresh secret. If they already have a **verified** TOTP secret, the endpoint returns `409` — they must call `DELETE /v1/me/totp` before re-enrolling.
+
+### Step 2 — User scans the QR code
+
+Show the `qr_code_data_url` as an `<img>` or let the user copy the `otpauth_uri` into their authenticator app. Both are generated server-side so you don't need a QR library.
+
+### Step 3 — Verify with the first code
+
+```http
+POST /v1/me/totp/verify
+Content-Type: application/json
+
+{ "code": "542178" }
+```
+
+The server checks the submitted 6-digit code against the stored secret with a ±1 step (30 s) tolerance. On success:
+
+- `TotpSecret.verified_at` is stamped.
+- `User.totp_enabled` flips to `true`.
+- If this is the user's first second factor, `User.two_factor_enabled` flips to `true` and `User.mfa_enabled_at` is stamped.
+
+An incorrect code returns `422` with `error_code: incorrect_code`. Repeated failures trigger the standard brute-force lockout.
+
+> **Note** — TOTP enrollment verify is a direct call, not a `Challenge`. The Challenge model is used only for sign-in second-factor proofs (see [Second-factor sign-in](/guides/second-factor-sign-in/)).
+
+### SDK example
+
+```tsx
+import { useUser } from '@authn.sh/sdk-react';
+
+function TotpEnroll() {
+    const { user } = useUser();
+    const [secret, setSecret] = React.useState(null);
+
+    const start = async () => {
+        const totp = await user.createTotp();
+        setSecret(totp);
+    };
+
+    const verify = async (code: string) => {
+        await user.verifyTotp({ code });
+    };
+
+    if (!secret) {
+        return <button onClick={start}>Enable authenticator app</button>;
+    }
+
+    return (
+        <>
+            <img src={secret.qrCodeDataUrl} alt="Scan in your authenticator app" />
+            <input
+                type="text"
+                inputMode="numeric"
+                placeholder="6-digit code"
+                onBlur={(e) => verify(e.target.value)}
+            />
+        </>
+    );
+}
+```
+
+The SDK also ships a pre-built `<TotpEnrollDialog />` component — see [Security section components](/reference/security-components/).
+
+## Backup codes
+
+Backup codes are single-use recovery codes the user stores somewhere safe. They let users bypass TOTP if they lose access to their authenticator app.
+
+### Generating codes
+
+```http
+POST /v1/me/backup-codes
+```
+
+Returns a `BackupCodeBatch` with a plaintext `codes[]` array. **This is the only time the codes are returned in plaintext.** The server stores hashes (Argon2id) and discards the plaintext after the response is sent. Instruct users to save the codes now — they cannot be retrieved later.
+
+The default batch size is 10 (configurable in `InstanceSettings.multi_factor.backup_codes.default_count`, range 4–24).
+
+### Regenerating codes
+
+Calling `POST /v1/me/backup-codes` again **replaces** the entire prior batch. Every previously-issued code stops working immediately, even codes that were never consumed. Always regenerate when the user reports their codes are lost, not when individual codes run out.
+
+### Removing backup codes
+
+```http
+DELETE /v1/me/backup-codes
+```
+
+Deletes every unused backup code and flips `User.backup_code_enabled` to `false`. If no other second factor remains, `User.two_factor_enabled` also flips to `false`. This call is idempotent — it succeeds even if the user had no codes.
+
+## Removing TOTP
+
+```http
+DELETE /v1/me/totp
+```
+
+Deletes the user's TOTP secret and flips `User.totp_enabled` to `false`. Backup codes are left intact — call `DELETE /v1/me/backup-codes` separately if you want to fully disable MFA. The Account Portal's "fully disable MFA" flow calls both endpoints sequentially.
+
+Returns `404` if the user has no enrolled TOTP secret.
+
+## Operator overrides (BAPI)
+
+### Verify a TOTP code server-side
+
+```http
+POST /v1/users/{user_id}/verify-totp
+Content-Type: application/json
+
+{ "code": "542178" }
+```
+
+Returns `{ "verified": true }` or `{ "verified": false }`. Use this to gate sensitive server-side actions on a fresh second-factor proof without routing the user through the FAPI sign-in flow. Repeated mismatches return `429`.
+
+This endpoint does **not** affect `TotpSecret.verified_at` — it's a verification check, not enrollment confirmation.
+
+### Reset a user's MFA entirely
+
+```http
+DELETE /v1/users/{user_id}/mfa
+```
+
+Deletes the user's TOTP secret and every unconsumed backup code. Flips all MFA flags to `false` and stamps `User.mfa_disabled_at`. Use this for support recovery when a user has lost both their authenticator and their backup codes.
+
+The call is idempotent — calling it on a user with no MFA enrollment returns the user unchanged.
+
+## Instance settings
+
+| Field | Default | Description |
+| ----- | ------- | ----------- |
+| `multi_factor.totp.enabled` | `true` | When `false`, new TOTP enrollments are refused and `totp` is excluded from `SignIn.supported_strategies`. |
+| `multi_factor.backup_codes.enabled` | `true` | When `false`, backup code generation is refused and `backup_code` is excluded from `supported_strategies`. |
+| `multi_factor.backup_codes.default_count` | `10` | Number of codes minted per `POST /v1/me/backup-codes`. Bounds: 4–24. |
+
+Disabling a strategy removes it from future sign-in flows. Stale enrollment rows survive the toggle but cannot be used to complete sign-in while the strategy is off.
+
+## REST reference
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/v1/me/totp` | Start TOTP enrollment — returns QR code + secret (one-time). |
+| `POST` | `/v1/me/totp/verify` | Confirm enrollment with the first generated code. |
+| `DELETE` | `/v1/me/totp` | Remove TOTP from the signed-in user's account. |
+| `POST` | `/v1/me/backup-codes` | (Re)generate backup codes — plaintext returned once. |
+| `DELETE` | `/v1/me/backup-codes` | Remove all backup codes from the signed-in user's account. |
+| `POST` | `/v1/users/{id}/verify-totp` | BAPI: verify a user's TOTP code without a sign-in flow. |
+| `DELETE` | `/v1/users/{id}/mfa` | BAPI: reset all MFA factors for a user (operator override). |

--- a/src/content/docs/guides/react-sign-in.md
+++ b/src/content/docs/guides/react-sign-in.md
@@ -46,6 +46,14 @@ Default is `path`. `virtual` is what the bundled Account Portal uses.
 
 A worked tenant integration ships in v0.1.x; for now, the [Account Portal source](https://github.com/authn-sh/authn/tree/main/resources/js/account-portal) is the canonical example.
 
+## Multi-factor authentication
+
+When a user has MFA enrolled, `<SignIn />` automatically presents the second-factor step after the first factor succeeds — no additional configuration needed. To build a custom second-factor UI or manage enrollment, see:
+
+- [Multi-factor authentication](/guides/multi-factor-authentication/) — TOTP enrollment and backup code management.
+- [Second-factor sign-in](/guides/second-factor-sign-in/) — what `needs_second_factor` looks like and how to issue and answer second-factor challenges.
+- [Security section components](/reference/security-components/) — the `<TotpEnrollDialog />`, `<BackupCodesDialog />`, and `<RemoveMfaDialog />` pre-built components.
+
 ## Adding and verifying email addresses
 
 When a user adds a secondary email via `<UserProfile />` or your own form, the new address starts unverified. Verification is a `Challenge` on the `EmailAddress` resource — the same pattern used for sign-in verification.

--- a/src/content/docs/guides/second-factor-sign-in.md
+++ b/src/content/docs/guides/second-factor-sign-in.md
@@ -1,0 +1,130 @@
+---
+title: Second-factor sign-in
+description: Handle the needs_second_factor step in your sign-in flow — TOTP and backup code challenges.
+---
+
+When a user with MFA enrolled completes their first factor, authn.sh advances the `SignIn` to `needs_second_factor` instead of completing the session. Your UI must issue a second-factor `Challenge` and answer it before the session activates.
+
+## What `needs_second_factor` looks like
+
+A `SignIn` in this state has:
+
+- `status: "needs_second_factor"` — the session is not yet active.
+- `supported_strategies[]` — the strategies the user can use for this sign-in, narrowed to factors they have enrolled **and** that are enabled on the environment. Possible values: `"totp"`, `"backup_code"`.
+
+```json
+{
+  "object": "sign_in",
+  "status": "needs_second_factor",
+  "supported_strategies": ["totp", "backup_code"],
+  "current_challenge_id": null
+}
+```
+
+The user sees this state after a successful password entry, email code, or magic-link click — whichever first factor they used.
+
+## Issuing a second-factor Challenge
+
+Call `POST /v1/client/sign-ins/{sid}/challenges` with the strategy the user chose. The server sets `step: "second"` on the resulting `Challenge`.
+
+```http
+POST /v1/client/sign-ins/{sid}/challenges
+Content-Type: application/json
+
+{ "strategy": "totp" }
+```
+
+Or for backup codes:
+
+```http
+POST /v1/client/sign-ins/{sid}/challenges
+Content-Type: application/json
+
+{ "strategy": "backup_code" }
+```
+
+The server validates that the chosen strategy appears in `SignIn.supported_strategies`. If it doesn't — for example because the user hasn't enrolled TOTP — the response is `422`.
+
+## Answering the Challenge
+
+For both `totp` and `backup_code`, submit `{ "code": "…" }` to the answer endpoint:
+
+```http
+POST /v1/client/sign-ins/{sid}/challenges/{cid}/answer
+Content-Type: application/json
+
+{ "code": "542178" }
+```
+
+For backup codes, use the `xxxx-xxxx` format (8 lowercase [Crockford base32](https://www.crockford.com/base32.html) characters, hyphen at midpoint):
+
+```http
+POST /v1/client/sign-ins/{sid}/challenges/{cid}/answer
+Content-Type: application/json
+
+{ "code": "abcd-efgh" }
+```
+
+On success the `SignIn` advances to `complete` and the `Client` has an active session. On a wrong code, the challenge returns `422` with `error_code: incorrect_code`. Excessive incorrect attempts flip the challenge to `status: failed` — issue a new challenge to retry.
+
+## SDK example
+
+```tsx
+import { useSignIn } from '@authn.sh/sdk-react';
+
+function SecondFactor() {
+    const { signIn } = useSignIn();
+    const [strategy, setStrategy] = React.useState<'totp' | 'backup_code'>('totp');
+
+    const submit = async (code: string) => {
+        const challenge = await signIn.createSecondFactorChallenge({ strategy });
+        await challenge.answer({ code });
+    };
+
+    const canUseBackupCode = signIn.supportedStrategies.includes('backup_code');
+
+    return (
+        <form onSubmit={(e) => {
+            e.preventDefault();
+            submit(new FormData(e.currentTarget).get('code') as string);
+        }}>
+            {strategy === 'totp' ? (
+                <input name="code" type="text" inputMode="numeric" placeholder="6-digit code" />
+            ) : (
+                <input name="code" type="text" placeholder="xxxx-xxxx" />
+            )}
+            <button type="submit">Verify</button>
+            {canUseBackupCode && strategy === 'totp' && (
+                <button type="button" onClick={() => setStrategy('backup_code')}>
+                    Use a backup code instead
+                </button>
+            )}
+        </form>
+    );
+}
+```
+
+The `<SignIn />` component handles this step automatically — no custom code needed if you're using the built-in form.
+
+## `supported_strategies` narrowing
+
+`SignIn.supported_strategies` reflects the intersection of:
+
+1. **What the user has enrolled** — `totp` appears only if `User.totp_enabled` is `true`; `backup_code` appears only if `User.backup_code_enabled` is `true`.
+2. **What the environment permits** — strategies disabled via `InstanceSettings.multi_factor` are excluded even if the user has stale enrollment rows for them.
+
+Always read `supported_strategies` from the live `SignIn` rather than assuming which factors are available. A user who enrolled TOTP before an operator toggled it off will see `supported_strategies: ["backup_code"]` if backup codes are still on.
+
+## Backup code format
+
+Backup codes are 8 Crockford base32 characters, lowercase, with a hyphen at the midpoint: `xxxx-xxxx`. The code field accepts the hyphenated form — strip whitespace on the client before submitting.
+
+Each code is single-use. Once consumed, it's marked spent and will return `incorrect_code` on subsequent attempts. When the user runs low (or has lost them), direct them to the [backup codes regeneration flow](/guides/multi-factor-authentication/#backup-codes).
+
+## REST reference
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/v1/client/sign-ins/{sid}/challenges` | Issue a second-factor challenge — body: `{ strategy: "totp" \| "backup_code" }`. |
+| `POST` | `/v1/client/sign-ins/{sid}/challenges/{cid}/answer` | Answer the challenge — body: `{ code: "…" }`. |
+| `GET` | `/v1/client/sign-ins/{sid}/challenges/{cid}` | Fetch the current challenge status. |

--- a/src/content/docs/reference/rest.md
+++ b/src/content/docs/reference/rest.md
@@ -16,6 +16,32 @@ The REST reference is generated from the [`authn-sh/openapi`](https://github.com
 - Errors follow the envelope `{ "errors": [{ "code", "message", "long_message", "meta" }], "trace_id" }`.
 - Pagination is opaque cursor-based: `?cursor=<token>&limit=<n>`. Responses include `meta.next_cursor` when more rows exist.
 
+## v0.3 endpoints (BAPI)
+
+### MFA admin overrides
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/v1/users/{id}/verify-totp` | Verify a user's TOTP code server-side (returns `{ verified: bool }`). |
+| `DELETE` | `/v1/users/{id}/mfa` | Reset all MFA factors for a user — deletes TOTP secret and all backup codes. |
+
+## v0.3 endpoints (FAPI)
+
+### TOTP enrollment
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/v1/me/totp` | Start TOTP enrollment — returns QR code, `otpauth_uri`, and plaintext secret (one-time). |
+| `POST` | `/v1/me/totp/verify` | Confirm enrollment by submitting the first generated 6-digit code. |
+| `DELETE` | `/v1/me/totp` | Remove the signed-in user's TOTP secret. |
+
+### Backup codes
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/v1/me/backup-codes` | (Re)generate backup codes — plaintext returned exactly once. |
+| `DELETE` | `/v1/me/backup-codes` | Delete all unused backup codes for the signed-in user. |
+
 ## v0.2 endpoints (BAPI)
 
 ### Organizations

--- a/src/content/docs/reference/security-components.md
+++ b/src/content/docs/reference/security-components.md
@@ -1,0 +1,115 @@
+---
+title: Security section components
+description: Pre-built React components for MFA enrollment, backup code management, and factor removal.
+---
+
+The `@authn.sh/sdk-react` package ships three pre-built dialog components for common MFA flows. They're rendered as modal dialogs on top of your existing UI and handle all state transitions internally.
+
+These components require `<AuthnProvider>` in the tree. They are available from v0.3 of `sdk-react`.
+
+## `<TotpEnrollDialog />`
+
+Guides the user through TOTP enrollment in three internal steps: generate secret → scan QR / copy URI → enter first code.
+
+```tsx
+import { TotpEnrollDialog } from '@authn.sh/sdk-react';
+
+<TotpEnrollDialog
+    open={isOpen}
+    onOpenChange={setIsOpen}
+    onSuccess={() => console.log('TOTP enrolled')}
+/>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `open` | `boolean` | — | Controls whether the dialog is visible. |
+| `onOpenChange` | `(open: boolean) => void` | — | Called when the dialog requests a visibility change (close button, backdrop click, Escape). |
+| `onSuccess` | `() => void` | — | Called after `POST /v1/me/totp/verify` succeeds and `User.totp_enabled` is `true`. |
+
+### Customization slots
+
+| Slot | Description |
+| ---- | ----------- |
+| `qrPlaceholder` | Replaces the default QR code `<img>`. Receives `{ qrCodeDataUrl, otpauthUri }`. |
+| `codeInput` | Replaces the 6-digit input and its surrounding label. Receives `{ onSubmit, isSubmitting, error }`. |
+
+### State machine
+
+The component advances through `idle → generating → qr_display → verifying → success → done`. Errors at `verifying` display inline and keep the component at `qr_display` so the user can retry. Calling `onOpenChange(false)` while in `qr_display` resets to `idle` — the unverified enrollment row persists server-side and will be overwritten on the next `open`.
+
+## `<BackupCodesDialog />`
+
+Displays a one-time plaintext reveal of newly-generated backup codes. Calls `POST /v1/me/backup-codes` on mount (when `open` first becomes `true`), shows the codes, and waits for the user to confirm they've saved them.
+
+```tsx
+import { BackupCodesDialog } from '@authn.sh/sdk-react';
+
+<BackupCodesDialog
+    open={isOpen}
+    onOpenChange={setIsOpen}
+    onSuccess={() => console.log('Backup codes saved')}
+/>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `open` | `boolean` | — | Controls whether the dialog is visible. |
+| `onOpenChange` | `(open: boolean) => void` | — | Called when the dialog requests a visibility change. Closing before confirmation shows a warning. |
+| `onSuccess` | `() => void` | — | Called after the user clicks the "I've saved my codes" confirmation. |
+
+### Customization slots
+
+| Slot | Description |
+| ---- | ----------- |
+| `codeList` | Replaces the default code grid. Receives `{ codes: string[] }`. |
+| `confirmButton` | Replaces the "I've saved my codes" button. |
+
+### State machine
+
+The component advances through `idle → generating → revealed → confirmed`. The dialog blocks closing (calls `onOpenChange(true)`) while in `revealed` unless the user first clicks the confirm button. This prevents accidental dismissal before the codes are stored. Closing in `idle` or after `confirmed` proceeds normally.
+
+> Regenerating codes replaces the entire prior batch. Old codes stop working immediately. The component does not warn about this — add copy in your surrounding UI if users need reminding.
+
+## `<RemoveMfaDialog />`
+
+Confirms and executes full MFA removal for the signed-in user. Calls `DELETE /v1/me/totp` and `DELETE /v1/me/backup-codes` sequentially.
+
+```tsx
+import { RemoveMfaDialog } from '@authn.sh/sdk-react';
+
+<RemoveMfaDialog
+    open={isOpen}
+    onOpenChange={setIsOpen}
+    onSuccess={() => console.log('MFA removed')}
+/>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `open` | `boolean` | — | Controls whether the dialog is visible. |
+| `onOpenChange` | `(open: boolean) => void` | — | Called when the dialog requests a visibility change. |
+| `onSuccess` | `() => void` | — | Called after both delete calls succeed and `User.two_factor_enabled` is `false`. |
+
+### Customization slots
+
+| Slot | Description |
+| ---- | ----------- |
+| `confirmationText` | Replaces the default warning prose. Receives no props. |
+| `confirmButton` | Replaces the "Remove MFA" destructive button. |
+
+### State machine
+
+`idle → confirming → removing_totp → removing_backup_codes → success`. If either delete call returns `404` (factor not enrolled), the component skips that step and continues. Errors at the removal steps display inline and leave the component at `confirming`.
+
+## Account Portal integration
+
+The `<UserProfile />` component's **Security** tab renders all three dialogs automatically when MFA is enabled for the environment. You only need the standalone components if you're building a custom account-management surface.
+
+The components read `InstanceSettings.multi_factor` from the environment bootstrap — factors disabled at the instance level are hidden automatically.


### PR DESCRIPTION
## Summary

- **Guides → Multi-factor authentication** — full walkthrough of TOTP enrollment (POST /v1/me/totp → verify), backup codes (one-time reveal, regeneration, removal), operator BAPI overrides, and instance settings
- **Guides → Second-factor sign-in** — `needs_second_factor` SignIn state, issuing `step:"second"` Challenges with `totp`/`backup_code`, answering with code, `supported_strategies` narrowing logic, backup code format (`xxxx-xxxx`)
- **Reference → Security section components** — `<TotpEnrollDialog />`, `<BackupCodesDialog />`, `<RemoveMfaDialog />` props, customization slots, and state machines (pending JS-3 for SDK implementation)
- **Reference → REST API** — v0.3 FAPI TOTP + backup-code endpoints and BAPI MFA admin override endpoints added
- Cross-links from `guides/react-sign-in` to the new MFA pages

Closes #7

## Test plan

- [x] `npm run build` exits clean — 19 pages, no errors
- [ ] CI green
- [ ] After JS-3 merges, verify SDK method names in examples match the shipped API