### PR TITLE
v0.5 docs — Passkeys / Theming / Localization / 6 OAuth presets / v1 React component reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.5.0] — 2026-05-11
+
+### Added
+
+- **Concepts → Passkeys** — the `Passkey` resource shape (public surface vs server-side credential bytes), the WebAuthn registration ceremony (begin / complete steps, the `PasskeyCreationOptions` envelope, `exclude_credentials[]` semantics), the sign-in (assertion) ceremony, the four passkey-specific error codes (`passkey_no_credentials`, `passkey_assertion_invalid`, `passkey_origin_mismatch`, `passkey_user_handle_mismatch`), RP-ID + origin allowlist guidance for self-hosters, and the recovery flow matrix.
+- **Customization → Theming** — the `Appearance` shape (variables / elements / layout), the full token + element-key catalogues, server-side editing via `PATCH /v1/instance/appearance` and the dashboard editor, client-side overrides via the `appearance` prop with deep per-key merge semantics, and four common recipes (brand-colour override, dark-mode palette, Tailwind-class layering, hidden optional fields).
+- **Customization → Localization** — resolution order (active locale → overrides → fallback → hard fallback), the five shipped locales, the `Localization` shape, the dashboard editor + `PATCH` sparse-merge / `null`-deletes-key semantics, the public CORS-open `GET /v1/localization/{locale}` endpoint with `Cache-Control` + `ETag` guidance, `{variable}` and `{count, plural, …}` placeholder syntax, and a walkthrough for adding a new locale via `supported_locales[]` + a full override blob.
+- **Social providers → Discord / Facebook / LinkedIn / X / GitLab / Slack** — one page per provider covering IdP-side app registration, default scopes, `attribute_mapping` defaults, and provider-specific footguns (Facebook's nested `picture.data.url`, X's missing `email`, Slack's "Sign in with Slack" vs "Add to Slack", GitLab self-managed instance via `custom_oidc`).
+- **React components reference (v1)** — final prop reference for `<SignIn />`, `<SignUp />`, `<UserProfile />`, `<UserButton />`, `<OrganizationProfile />`, `<OrganizationSwitcher />`, including the `routing` / `path` / `appearance` / `localization` props, the internal state machines, custom-page slots (`<UserProfile.Page />`, `<OrganizationProfile.Page />`), and composition hooks for users who want finer-grained control.
+
+### Changed
+
+- **Webhooks concept** — event-type catalogue extended with the v0.4 events (`oauthProvider.*`, `externalAccount.*`, `phoneNumber.*`, `smsTemplate.*`) and the v0.5 events (`passkey.added`, `passkey.removed`, `instance.config.appearance_updated`, `localization.updated`). The two configuration events carry a `{ previous, current, diff }` triple so audit handlers can replay the change without diffing full blobs.
+- **REST reference** auto-rebuilt against the v0.5 OpenAPI bundle: `Passkey`, `PasskeyCreationOptions`, `PasskeyRequestOptions`, `PasskeyAttestation`, `PasskeyAssertion`, `Appearance`, `Localization`, `LocalizationUpdateRequest` schemas; FAPI `/v1/me/passkeys` CRUD + `/begin-registration` / `/complete-registration/{cid}` ceremony paths; FAPI sign-in `Challenge.strategy: passkey` ceremony; BAPI `/v1/instance/appearance` + `/v1/instance/localization` (GET / PUT / PATCH); the public CORS-open FAPI `/v1/localization/{locale}` endpoint; six new preset `provider_key` values on `OauthProvider.yaml` (`discord`, `facebook`, `linkedin`, `x`, `gitlab`, `slack`).
+- Sidebar reorganized — new top-level **Customization**, **Social providers**, and **React components** sections.
+
 ## [0.4.0] — 2026-05-10
 
 ### Added

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -39,6 +39,7 @@ export default defineConfig({
                         { label: 'Workspaces, projects, environments', slug: 'concepts/tenancy' },
                         { label: 'API keys', slug: 'concepts/api-keys' },
                         { label: 'Sessions and tokens', slug: 'concepts/sessions-and-tokens' },
+                        { label: 'Passkeys', slug: 'concepts/passkeys' },
                         { label: 'Webhooks', slug: 'concepts/webhooks' },
                     ],
                 },
@@ -57,6 +58,35 @@ export default defineConfig({
                         { label: 'Multi-factor authentication', slug: 'guides/multi-factor-authentication' },
                         { label: 'Second-factor sign-in', slug: 'guides/second-factor-sign-in' },
                         { label: 'SMS MFA', slug: 'guides/sms-mfa' },
+                    ],
+                },
+                {
+                    label: 'Customization',
+                    items: [
+                        { label: 'Theming', slug: 'customization/theming' },
+                        { label: 'Localization', slug: 'customization/localization' },
+                    ],
+                },
+                {
+                    label: 'Social providers',
+                    items: [
+                        { label: 'Discord', slug: 'social-providers/discord' },
+                        { label: 'Facebook', slug: 'social-providers/facebook' },
+                        { label: 'LinkedIn', slug: 'social-providers/linkedin' },
+                        { label: 'X (Twitter)', slug: 'social-providers/x' },
+                        { label: 'GitLab', slug: 'social-providers/gitlab' },
+                        { label: 'Slack', slug: 'social-providers/slack' },
+                    ],
+                },
+                {
+                    label: 'React components',
+                    items: [
+                        { label: '<SignIn />', slug: 'sdk/react/components/sign-in' },
+                        { label: '<SignUp />', slug: 'sdk/react/components/sign-up' },
+                        { label: '<UserProfile />', slug: 'sdk/react/components/user-profile' },
+                        { label: '<UserButton />', slug: 'sdk/react/components/user-button' },
+                        { label: '<OrganizationProfile />', slug: 'sdk/react/components/organization-profile' },
+                        { label: '<OrganizationSwitcher />', slug: 'sdk/react/components/organization-switcher' },
                     ],
                 },
                 {

--- a/src/content/docs/concepts/passkeys.md
+++ b/src/content/docs/concepts/passkeys.md
@@ -1,0 +1,155 @@
+---
+title: Passkeys
+description: How authn.sh models WebAuthn credentials, the registration and sign-in ceremonies, and what self-hosters need to configure.
+---
+
+A **passkey** is a phishing-resistant credential bound to a specific origin — a private key stored on the user's device (a hardware security key, a platform authenticator like Touch ID / Windows Hello, or a cross-device synced passkey from iCloud Keychain / Google Password Manager / 1Password) and a public key registered against the user's authn.sh account. Sign-in is a challenge / response: the server sends a random nonce, the authenticator signs it with the private key, and the server verifies the signature with the public key it stored at registration time.
+
+Passkeys are available from v0.5 of authn.sh.
+
+## The model
+
+A `Passkey` is one registered authenticator. A user with both a YubiKey and a MacBook Touch ID has two `Passkey` rows.
+
+```json
+{
+  "id": "pkey_01HKX9SY9V7H7TF8C8K7J9X4ZA",
+  "object": "passkey",
+  "nickname": "YubiKey 5C",
+  "transports": ["usb", "nfc"],
+  "aaguid": "ee882879-721c-4913-9775-3dfcce97072a",
+  "verified": true,
+  "last_used_at": 1714896500000,
+  "created_at": 1714723000000,
+  "updated_at": 1714896500000
+}
+```
+
+The raw credential ID bytes, the COSE-encoded public key, and the authenticator's signature counter never appear in any payload — those are the secret operational fields the WebAuthn server library reads directly from the database during assertion verification. They're stored encrypted at rest and exposed only inside the server.
+
+What the SDK sees is the human-facing surface:
+
+- `nickname` — the label the user picked. Defaults to a server-generated string at registration time if the SDK doesn't supply one; rendered in `<UserProfile />` so the user can tell their authenticators apart.
+- `transports[]` — the transports the authenticator advertised at registration (`usb`, `nfc`, `ble`, `internal`, `hybrid`). Surfaced verbatim to the browser at sign-in time so the WebAuthn UI can hint the right discovery flow.
+- `aaguid` — an opaque 128-bit identifier the authenticator chose to disclose, surfacing the authenticator model. `null` when the authenticator returned the zero AAGUID (the common case for platform authenticators that decline to attest a model).
+- `verified` — `true` once the registration ceremony's attestation response was accepted. Unverified rows are garbage-collected if the ceremony is never completed.
+- `last_used_at` — most recent successful assertion against this credential. `null` until the first successful use after registration.
+
+The user's full passkey list also hangs off the `User` resource as `User.passkeys[]`, with a `User.passkey_count` convenience field for "does this user have *any* passkey".
+
+## Registration (enrollment) ceremony
+
+Registration is a two-step ceremony that mirrors the WebAuthn L3 spec. The SDK wraps both steps; if you're using `<UserProfile />` you don't have to touch any of this. If you're building a custom enrollment surface, the dance is:
+
+### Step 1 — Begin the ceremony
+
+Open a `Challenge` carrying the server-built `PublicKeyCredentialCreationOptions`:
+
+```http
+POST /v1/me/passkeys/begin-registration
+```
+
+The response is a `Challenge` with `creation_options` set to a `PasskeyCreationOptions` envelope. The SDK passes that envelope verbatim to `navigator.credentials.create({ publicKey })` after URL-safe base64 decoding `challenge`, `user.id`, and every `exclude_credentials[].id`.
+
+Notable defaults:
+
+- `rp.id` is the **effective RP ID** — the apex domain the credential will be scoped to. Matches `Environment.host` minus the `<env_slug>.` subdomain unless the operator overrode it.
+- `authenticator_selection.resident_key: "preferred"` — the v0.5 default. Enables username-less sign-in when the authenticator supports a discoverable credential, and falls back gracefully when it doesn't.
+- `authenticator_selection.user_verification: "preferred"` — accepts user verification (biometric / PIN) when the authenticator offers it.
+- `attestation: "none"` — the server doesn't validate authenticator provenance in v0.5.
+- `exclude_credentials[]` — every existing `Passkey` for this user. The authenticator refuses to enroll if any match, so the user doesn't accidentally register the same authenticator twice.
+
+A `Passkey` row is created in the unverified state by this step.
+
+### Step 2 — Complete the ceremony
+
+After the browser returns from `navigator.credentials.create()`, post the attestation back keyed by the `challenge_id` from step 1:
+
+```http
+POST /v1/me/passkeys/complete-registration/{challenge_id}
+Content-Type: application/json
+
+{
+  "attestation": { /* base64url-encoded WebAuthn AuthenticatorAttestationResponse */ },
+  "nickname": "YubiKey 5C"        // optional; falls back to a server-generated default
+}
+```
+
+The server verifies the attestation against the challenge nonce and the RP ID, flips the row to `verified: true`, and returns the full `Passkey`. The pending row is garbage-collected if step 2 never runs.
+
+### React
+
+```tsx
+import { useUser } from '@authn.sh/sdk-react';
+
+const { user } = useUser();
+
+await user.createPasskey({ nickname: 'YubiKey 5C' });
+```
+
+`createPasskey()` runs both steps and either resolves with the new `Passkey` or throws with one of the `passkey_*` error codes (see below).
+
+## Sign-in (authentication) ceremony
+
+Sign-in reuses the standard `Challenge` envelope; passkeys are just another first-factor strategy.
+
+```http
+POST /v1/sign-ins/{sid}/challenges
+Content-Type: application/json
+
+{ "strategy": "passkey" }
+```
+
+The response carries a `Challenge` with `request_options` set to a `PasskeyRequestOptions` envelope — the spec-shaped `PublicKeyCredentialRequestOptions`. The SDK passes it to `navigator.credentials.get({ publicKey })`, then posts the assertion back:
+
+```http
+POST /v1/sign-ins/{sid}/challenges/{cid}/answer
+Content-Type: application/json
+
+{
+  "assertion": { /* base64url-encoded WebAuthn AuthenticatorAssertionResponse */ }
+}
+```
+
+On success the parent `SignIn` advances to `status: complete` and the session is minted. On failure the answer endpoint returns a `Challenge` with `status: failed` and an `error_code` from the catalogue below.
+
+### React
+
+```tsx
+import { useSignIn } from '@authn.sh/sdk-react';
+
+const { signIn } = useSignIn();
+
+await signIn.authenticateWithPasskey();
+```
+
+`authenticateWithPasskey()` calls `POST /sign-ins`, requests the passkey challenge, runs `navigator.credentials.get()`, posts the assertion, and resolves with the completed `SignIn` — or throws with one of the `passkey_*` errors.
+
+## Error codes
+
+The passkey assertion endpoint surfaces four distinct failures so the SDK can pick the right user-facing message:
+
+| Code | When it fires |
+| --- | --- |
+| `passkey_no_credentials` | The user has no `Passkey` row that the requested RP ID can challenge. UI should redirect to a fallback strategy (password / email code). |
+| `passkey_assertion_invalid` | Signature verification failed against the stored public key. Almost always means the user picked the wrong authenticator (or someone is trying to forge an assertion). |
+| `passkey_origin_mismatch` | The assertion was created against a different origin than the one the server expects. See "RP ID + origin allowlist" below. |
+| `passkey_user_handle_mismatch` | The `user.id` returned by the authenticator doesn't match any `User` in this environment. Indicates a credential from a different deployment or a stale roaming key. |
+
+## RP ID + origin allowlist (self-hosters, read this)
+
+WebAuthn binds every credential to a specific **RP ID** — usually the apex domain serving the FAPI. authn.sh derives RP ID from each environment's FAPI host at request time: if your FAPI lives at `acme.authn.example.com`, the RP ID defaults to `authn.example.com` and the server accepts assertions with origins matching `*.authn.example.com`.
+
+If you self-host with a non-default DNS layout (e.g. FAPI at `auth.acme.com` but the Account Portal at `accounts.acme.com`), you need to configure the FAPI host correctly so the derived RP ID covers both origins. The chart's [`AUTHN_APP_URL`](https://github.com/authn-sh/helm) (helm) and the CDK construct's `appUrl` (cdk) drive this — set them to the **registrable apex** you want the RP ID scoped to, not the FAPI subdomain.
+
+The `passkey_origin_mismatch` error is what you'll see at sign-in time if the derived RP ID is wrong. The fix is the FAPI host configuration; never change it on a live deployment with already-enrolled passkeys, because every existing credential will be silently locked out.
+
+## Recovery flows
+
+A passkey-bound user who loses every authenticator they've enrolled can't sign in with that strategy. authn.sh's recovery story:
+
+1. **The user still has a second authenticator.** Sign in with the surviving one, delete the lost passkey from `<UserProfile />`, and enroll a fresh one. This is the encouraged path — `<UserProfile />` nudges users to enroll at least two passkeys.
+2. **The user still has another first-factor strategy enabled** (password / email code / OAuth). Sign in with the fallback, then delete the lost passkey and enroll a fresh one.
+3. **The user has no first-factor fallback and only one passkey.** They're locked out at the FAPI level. An operator can either re-enable a password / email-code strategy on the instance (which lets the user reset via the standard email flow) or delete the orphan `Passkey` rows via BAPI and walk the user through re-enrollment from a trusted device. For B2B deployments, lean on backup codes (the same `BackupCodeBatch` surface MFA uses) or invite-driven recovery rather than expecting the user to remember a password.
+
+Backup codes are not currently a passkey recovery factor — they're scoped to second-factor recovery only. If you want a single-string recovery escape hatch for passkey users, enable email codes alongside the passkey strategy so a `signIn.start.email_code` flow can mint a fresh session for re-enrollment.

--- a/src/content/docs/concepts/webhooks.md
+++ b/src/content/docs/concepts/webhooks.md
@@ -103,4 +103,33 @@ permission.deleted
 
 The `data` field of each event carries the full resource snapshot — `Organization`, `OrganizationMembership`, `OrganizationInvitation`, `OrganizationDomain`, `OrganizationMembershipRequest`, `Role`, or `Permission` — so handlers don't need a follow-up fetch in most cases. Magic-link sign-in/sign-up does not introduce its own event type; the outgoing email is reported via the existing `email.created` event.
 
+### v0.4
+
+```
+oauthProvider.created
+oauthProvider.updated
+oauthProvider.deleted
+externalAccount.created
+externalAccount.updated
+externalAccount.deleted
+phoneNumber.created
+phoneNumber.updated
+phoneNumber.deleted
+smsTemplate.updated
+smsTemplate.reverted
+```
+
+`data` carries `OauthProvider`, `ExternalAccount`, `PhoneNumber`, or `SmsTemplate`. The SMS-template `revert` event re-emits the row in its post-revert (back-to-default) shape.
+
+### v0.5
+
+```
+passkey.added
+passkey.removed
+instance.config.appearance_updated
+localization.updated
+```
+
+The two passkey events carry a `Passkey` resource on `data`. The two configuration events carry a `{ previous, current, diff }` triple — the `diff` is shaped like the corresponding `PATCH` request body (`Appearance` for appearance, `LocalizationUpdateRequest` for localization), so audit handlers can replay the change without diffing the full blobs themselves.
+
 The live list is published via `GET /v1/event-types` against the BAPI.

--- a/src/content/docs/customization/localization.md
+++ b/src/content/docs/customization/localization.md
@@ -1,0 +1,155 @@
+---
+title: Localization
+description: How authn.sh resolves translated strings, the five shipped locales, and how operators tweak copy per-environment.
+---
+
+The bundled components render every user-facing string through a localization layer. Five locales ship with canonical catalogs in `@authn.sh/sdk-react`; operators tweak copy per-locale from the dashboard without rebuilding the SDK.
+
+Localization is available from v0.5 of authn.sh.
+
+## How resolution works
+
+For every key the SDK renders, the runtime walks four sources in order. The first source that has a non-`null` value for the key wins:
+
+```
+default_catalog[active_locale]
+  ⊕ overrides[active_locale]             ← operator's per-locale tweak
+  ⊕ default_catalog[fallback_locale]     ← used for keys the active locale didn't translate
+  ⊕ overrides[fallback_locale]
+  ⊕ (per-key hard fallback, baked into the SDK)
+```
+
+This means:
+
+- **Canonical defaults** are shipped with the SDK and updated through SDK releases — `0.5.x` ships a complete `en-US` catalogue.
+- **Operator overrides** are sparse — you only set the keys you want to change. Unmentioned keys fall through to the canonical default.
+- **Fallback locale** picks up the slack when the active locale doesn't translate a specific key (typical for niche keys an operator added for `en-US` but hasn't translated yet for `pt-BR`).
+- **Per-key hard fallback** is the absolute floor — every key in the SDK has a baked-in English string the runtime emits if literally everything else is missing. You'll never see a raw key in the UI.
+
+## The five shipped locales
+
+| BCP-47 | Language |
+| --- | --- |
+| `en-US` | English (United States) |
+| `pt-BR` | Portuguese (Brazil) |
+| `es-ES` | Spanish (Spain) |
+| `fr-FR` | French (France) |
+| `de-DE` | German (Germany) |
+
+The SDK exposes the active locale via `useLocale()` and the language picker via `<UserButton />`'s **Language** affordance. The active locale is resolved as:
+
+1. The user's `User.public_metadata.locale` if set.
+2. The browser's `Accept-Language` header, intersected with `supported_locales[]`.
+3. `default_locale` from the environment's `Localization` config.
+
+## The `Localization` shape
+
+Per-environment configuration stored as `Environment.localization`:
+
+```ts
+interface Localization {
+  default_locale: string;
+  fallback_locale: string;
+  supported_locales: string[];
+  overrides: Record<string, Record<string, string>>;
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `default_locale` | BCP-47 tag used when the SDK can't read a user preference. Must be in `supported_locales`. |
+| `fallback_locale` | BCP-47 tag the SDK falls back to per-key when the active locale doesn't have a translation. Typically `en-US`. |
+| `supported_locales` | The locales the SDK surfaces in the language picker and auto-detects from `Accept-Language`. Must include `default_locale` and `fallback_locale`. |
+| `overrides` | Per-locale operator overrides. Outer key is a BCP-47 tag; inner map is dot-keyed canonical keys to translated strings. |
+
+Locales not present in the bundled default catalog **must** have a full override blob — the BAPI validator returns `unsupported_locale` if a caller adds an entry to `supported_locales[]` without a matching default or override. This is the affordance for shipping a sixth (or 60th) locale before authn.sh upstreams it.
+
+## The dashboard editor
+
+Open **Dashboard → Configure → Localization**. The editor:
+
+- Renders side-by-side **canonical / override** columns per locale, so you see exactly what's being overridden.
+- Shows the `{variable}` and `{count, plural, …}` placeholders inline with validation — the save button is disabled if your override drops a required placeholder.
+- Lives-previews the changes against the bundled `<SignIn />` / `<SignUp />` / `<UserProfile />` components.
+
+Each save goes to `PATCH /v1/instance/localization` — a sparse merge. Setting a key's value to `null` in the PATCH body **deletes** that single override (the key falls back to the canonical default) without affecting the rest of the locale.
+
+A full overwrite is available via `PUT /v1/instance/localization` for export / import flows. The current blob is readable via `GET /v1/instance/localization` (BAPI, operator auth) or as `Environment.localization` on the FAPI `GET /v1/environment` response (public, used by the SDK at boot).
+
+### Public localization endpoint
+
+The SDK also fetches the live override map for each locale via a CORS-open FAPI path:
+
+```http
+GET /v1/localization/{locale}
+```
+
+Hit on every Account Portal / SDK page load. The response carries:
+
+- `Cache-Control: public, max-age=300, stale-while-revalidate=3600` — five-minute fresh window, hour-long stale-revalidate window.
+- An `ETag` that mirrors `Environment.localization.override_etag` — operator edits invalidate it immediately.
+
+If you front your FAPI host with your own CDN, respect those headers so that operator edits in the dashboard propagate to end-user browsers within seconds rather than hours. See [Operating an instance](https://github.com/authn-sh/helm#operating-an-instance) in the helm README for details.
+
+## Placeholder syntax
+
+Two interpolation flavours, both standard ICU MessageFormat subsets:
+
+### `{variable}` — simple substitution
+
+```text
+"signIn.start.greeting": "Welcome back, {firstName}!"
+```
+
+The SDK substitutes the variable at render time. If the variable is missing from the context, the placeholder is left untouched (it's a bug for the SDK to call into a key without supplying the expected variable; we surface it loudly in dev mode).
+
+### `{count, plural, …}` — pluralisation
+
+```text
+"reference.passkeys.count": "{count, plural, one {# passkey} other {# passkeys}}"
+```
+
+Standard CLDR plural categories: `zero`, `one`, `two`, `few`, `many`, `other`. Not every locale uses every category — the SDK picks the right branch based on the active locale's CLDR plural rules. `#` substitutes the count.
+
+Locale-aware number formatting comes for free (`1,234` in `en-US`, `1.234` in `de-DE`) because the SDK runs the substitution through `Intl.PluralRules` + `Intl.NumberFormat`.
+
+## Adding a new locale
+
+If your environment needs a locale outside the five shipped ones — say, `ja-JP`:
+
+1. Translate the canonical catalogue from `@authn.sh/sdk-react`. The full catalogue is exported as `defaultLocaleCatalogues['en-US']` for convenience.
+2. POST the override blob:
+
+   ```http
+   PATCH /v1/instance/localization
+   Content-Type: application/json
+
+   {
+     "supported_locales": ["en-US", "pt-BR", "es-ES", "fr-FR", "de-DE", "ja-JP"],
+     "overrides": {
+       "ja-JP": {
+         "signIn.start.title": "サインイン",
+         "signIn.start.subtitle": "メールアドレスを入力してください",
+         "...": "..."
+       }
+     }
+   }
+   ```
+
+3. Users with `Accept-Language: ja` (and no `User.public_metadata.locale` override) will see the new locale immediately.
+
+If you'd like a locale upstreamed into the SDK so other operators can pick it up without an override blob, contributions are welcome — the canonical catalogues live in [authn-sh/javascript](https://github.com/authn-sh/javascript) under `packages/sdk-react/src/locales/`. (Translations of these docs themselves are post-v1.0.)
+
+## Error codes
+
+The localization BAPI validator can refuse a `PATCH` with:
+
+| Code | When it fires |
+| --- | --- |
+| `invalid_locale_code` | A key in `supported_locales[]` or `overrides` isn't a syntactically valid BCP-47 tag. |
+| `unsupported_locale` | A locale was added to `supported_locales[]` without an entry in `overrides` and isn't in the bundled default catalog. |
+| `unknown_localization_key` | An `overrides[locale]` dictionary contains a key that isn't in the canonical SDK catalogue. The catalogue is the source of truth; if you need a new key, that's an SDK contribution. |
+
+## Webhook events
+
+Edits emit a `localization.updated` webhook event with the previous + current blob and a diff. Useful for audit pipelines, for caches that want to invalidate proactively, or for cross-environment sync if you want to mirror copy from a staging environment to production.

--- a/src/content/docs/customization/theming.md
+++ b/src/content/docs/customization/theming.md
@@ -1,0 +1,265 @@
+---
+title: Theming
+description: Customize the visual appearance of authn.sh's bundled components — colours, typography, layout, per-element class overrides.
+---
+
+The bundled components (`<SignIn />`, `<SignUp />`, `<UserProfile />`, `<UserButton />`, …) are customisable along three axes: **CSS design tokens**, **per-element className overrides**, and **structural layout toggles**. The configuration is per-environment; once an operator sets it, every consumer of the SDK in that environment picks it up automatically without a code change.
+
+Theming is available from v0.5 of authn.sh.
+
+## The `Appearance` shape
+
+Three blocks, every block optional, every key inside it optional. Missing keys mean "use the default":
+
+```ts
+interface Appearance {
+  variables?: {
+    colorPrimary?: string;
+    colorBackground?: string;
+    colorText?: string;
+    colorTextOnPrimary?: string;
+    colorInputBackground?: string;
+    colorInputText?: string;
+    colorDanger?: string;
+    colorSuccess?: string;
+    colorWarning?: string;
+    colorNeutral?: string;
+    fontFamily?: string;
+    fontFamilyButtons?: string;
+    fontSize?: string;
+    borderRadius?: string;
+    spacingUnit?: string;
+  };
+  elements?: Record<ElementName, string>;
+  layout?: {
+    logoImageUrl?: string | null;
+    logoLinkUrl?: string | null;
+    socialButtonsPlacement?: 'top' | 'bottom';
+    socialButtonsVariant?: 'blockButton' | 'iconButton';
+    showOptionalFields?: boolean;
+    privacyPageUrl?: string | null;
+    termsPageUrl?: string | null;
+    helpPageUrl?: string | null;
+    animations?: boolean;
+  };
+}
+```
+
+### `variables` — CSS design tokens
+
+A loose-string map applied as CSS custom properties on the component root. The server doesn't validate hex vs `rgb()` vs named colours — whatever you write round-trips. Lengths can be `px`, `rem`, `em`, `%`.
+
+```json
+{
+  "variables": {
+    "colorPrimary": "#0a84ff",
+    "colorTextOnPrimary": "#ffffff",
+    "borderRadius": "0.5rem",
+    "fontFamily": "Inter, system-ui, sans-serif"
+  }
+}
+```
+
+The full token catalogue:
+
+| Token | Applied to |
+| --- | --- |
+| `colorPrimary` | Buttons, focus rings, links. |
+| `colorBackground` | Card / surface background. |
+| `colorText` | Default body text colour. |
+| `colorTextOnPrimary` | Text rendered on top of `colorPrimary` (e.g. primary button labels). |
+| `colorInputBackground` | Form input background. |
+| `colorInputText` | Form input text colour. |
+| `colorDanger` | Destructive / error accent (delete buttons, validation errors). |
+| `colorSuccess` | Success accent (verified states, success banners). |
+| `colorWarning` | Warning accent (pending verification, caution banners). |
+| `colorNeutral` | Neutral accent (secondary buttons, muted text). |
+| `fontFamily` | Default font for body copy. |
+| `fontFamilyButtons` | Button typography. Falls back to `fontFamily`. |
+| `fontSize` | Base font size (e.g. `"14px"`, `"1rem"`). |
+| `borderRadius` | Component corner radius. |
+| `spacingUnit` | Spacing scale unit; multiplied for padding / gap. |
+
+### `elements` — per-element className overrides
+
+A map keyed by stable element names. Values are space-separated className strings the SDK **appends** to the default class list. This is the affordance for layering Tailwind / utility classes on top of authn.sh's defaults without owning the markup.
+
+```json
+{
+  "elements": {
+    "card": "shadow-2xl border border-slate-700",
+    "formButtonPrimary": "tracking-wide uppercase",
+    "formFieldInput": "ring-1 ring-slate-700"
+  }
+}
+```
+
+The catalogue of stable element keys:
+
+| Element key | Targets |
+| --- | --- |
+| `formButtonPrimary` | Primary submit buttons. |
+| `formButtonReset` | Secondary / cancel buttons. |
+| `formFieldInput` | All `<input>` elements. |
+| `formFieldLabel` | `<label>` text above fields. |
+| `formFieldErrorText` | Field-level validation error text. |
+| `card` | The outer card / dialog surface. |
+| `headerTitle` | Card title (e.g. "Sign in"). |
+| `headerSubtitle` | Card subtitle. |
+| `dividerLine` | The horizontal rule between social buttons and form. |
+| `dividerText` | The "or" label that floats over the divider. |
+| `socialButtonsBlockButton` | OAuth provider buttons in `blockButton` variant. |
+| `socialButtonsProviderIcon` | Provider icon inside a social button. |
+| `footerActionLink` | "Don't have an account? Sign up" footer link. |
+| `userPreviewMainIdentifier` | The user's email / name in `<UserButton />` and `<UserProfile />`. |
+| `userPreviewSecondaryIdentifier` | The user's secondary identifier (typically a handle / org). |
+| `userButtonAvatarBox` | `<UserButton />`'s avatar circle. |
+| `userButtonPopoverActionButton` | Action rows inside the `<UserButton />` popover. |
+
+Unknown keys are ignored — the SDK only honours the stable catalogue.
+
+### `layout` — structural toggles
+
+Structural opts applied to the component shell:
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `logoImageUrl` | `string \| null` | `null` | Image rendered above the card title. `null` hides the logo. |
+| `logoLinkUrl` | `string \| null` | environment `home_url` | Where the logo links to when clicked. |
+| `socialButtonsPlacement` | `'top' \| 'bottom'` | `'top'` | Render the OAuth provider buttons above or below the identifier form. |
+| `socialButtonsVariant` | `'blockButton' \| 'iconButton'` | `'blockButton'` | `blockButton` — labelled "Continue with Google" buttons stacked vertically. `iconButton` — icon-only buttons laid out horizontally. |
+| `showOptionalFields` | `boolean` | `true` | When `false`, fields the environment marks as `optional` (e.g. `first_name`, `last_name`) are hidden on the sign-up form. |
+| `privacyPageUrl` | `string \| null` | `null` | Linked from the footer / sign-up legal copy. |
+| `termsPageUrl` | `string \| null` | `null` | Linked from the footer / sign-up legal copy. |
+| `helpPageUrl` | `string \| null` | `null` | Linked from the help affordance in `<UserProfile />`. |
+| `animations` | `boolean` | `true` | When `false`, the SDK uses `prefers-reduced-motion`-style static styling. |
+
+## Server-side appearance — the dashboard editor
+
+Open **Dashboard → Configure → Appearance**. The editor renders the same `<SignIn />`, `<SignUp />`, `<UserProfile />`, `<UserButton />` your end users see, in a live preview pane. Edits propagate through the existing FAPI surface:
+
+- Each save call goes to `PATCH /v1/instance/appearance` — a sparse merge against the current blob.
+- A full overwrite is available via `PUT /v1/instance/appearance` if you want to replace the entire shape (useful for export / import flows).
+- The current blob is readable via `GET /v1/instance/appearance` (BAPI, operator auth) or as `Environment.appearance` on the FAPI `GET /v1/environment` response (public, used by the SDK at boot).
+
+The FAPI response wraps the blob with an `etag` — `sha256(canonical-JSON(appearance))` — so the SDK can short-circuit re-renders when the config hasn't changed.
+
+### Cache + edit propagation
+
+The FAPI surface for `GET /v1/environment` serves with `ETag` + a short `Cache-Control` window. Edits saved in the dashboard propagate to end-user browsers within a few seconds (the SDK revalidates on focus + per-page-load), so designers can iterate against a real production-style preview.
+
+Self-hosters running their own CDN in front of the FAPI host should respect the `Cache-Control` headers the app emits — see [Operating an instance](https://github.com/authn-sh/helm#operating-an-instance) in the helm README for details.
+
+## Client-side appearance — the `appearance` prop
+
+When you want to override appearance in just one consumer (e.g. embed authn in a customer-portal page with a custom palette) without touching the per-environment config, pass an `appearance` prop directly to the component. The prop and the server-side blob are merged at render time:
+
+```tsx
+import { SignIn } from '@authn.sh/sdk-react';
+
+<SignIn
+  appearance={{
+    variables: {
+      colorPrimary: '#7c3aed',
+    },
+    elements: {
+      formButtonPrimary: 'font-mono uppercase tracking-widest',
+    },
+  }}
+/>
+```
+
+### Merge semantics
+
+The merge is **per-key**, deep, with the prop winning:
+
+- `variables` — token-by-token override. Keys absent from the prop fall through to the server blob; keys absent from both fall to the SDK default.
+- `elements` — className strings from prop and server are **concatenated** (not overwritten). This is intentional — operators can establish a brand baseline via the dashboard, and a specific embed can layer additional utility classes on top without losing the baseline.
+- `layout` — key-by-key override. Same fall-through as `variables`.
+
+To explicitly null-out a server-side value from the prop, pass `null`:
+
+```tsx
+<SignIn appearance={{ layout: { logoImageUrl: null } }} />
+```
+
+This hides the operator-configured logo in just this embed, without touching the dashboard setting.
+
+## Common recipes
+
+### Brand colour override
+
+Just the primary accent — most consumers won't need anything else:
+
+```json
+{
+  "variables": {
+    "colorPrimary": "#0a84ff",
+    "colorTextOnPrimary": "#ffffff"
+  }
+}
+```
+
+### Dark-mode palette
+
+Full token sweep for an inverted theme:
+
+```json
+{
+  "variables": {
+    "colorPrimary": "rgb(10 132 255)",
+    "colorBackground": "#0b1220",
+    "colorText": "#e6edf3",
+    "colorTextOnPrimary": "#ffffff",
+    "colorInputBackground": "#111827",
+    "colorInputText": "#e6edf3",
+    "colorDanger": "#f87171",
+    "colorSuccess": "#34d399",
+    "colorWarning": "#fbbf24",
+    "colorNeutral": "#9ca3af"
+  }
+}
+```
+
+### Tailwind-style custom button
+
+The default primary button gets Tailwind utility classes layered on top:
+
+```json
+{
+  "elements": {
+    "formButtonPrimary": "tracking-wide uppercase shadow-lg hover:shadow-xl"
+  }
+}
+```
+
+The SDK's own primary-button class still applies underneath — the override appends rather than replaces.
+
+### Hide optional sign-up fields
+
+Sign-ups with the absolute minimum identifier-and-password surface:
+
+```json
+{
+  "layout": {
+    "showOptionalFields": false
+  }
+}
+```
+
+`first_name` / `last_name` (when they're marked optional on the environment) disappear from the sign-up form. Required fields are unaffected.
+
+### Icon-only social buttons at the bottom of the form
+
+```json
+{
+  "layout": {
+    "socialButtonsPlacement": "bottom",
+    "socialButtonsVariant": "iconButton"
+  }
+}
+```
+
+## Webhook events
+
+When operator-driven edits happen, the FAPI emits an `instance.config.appearance_updated` webhook event with the previous + current blob and a diff. Useful for audit pipelines or for caches that want to invalidate proactively rather than wait for the next ETag check.

--- a/src/content/docs/sdk/react/components/organization-profile.md
+++ b/src/content/docs/sdk/react/components/organization-profile.md
@@ -1,0 +1,65 @@
+---
+title: <OrganizationProfile />
+description: The bundled organization-settings component — members, invitations, domain enrollment, roles, danger zone.
+---
+
+`<OrganizationProfile />` renders the complete admin surface for the user's currently active organization. Available from v1 of `@authn.sh/sdk-react`.
+
+## Quickstart
+
+```tsx
+import { OrganizationProfile } from '@authn.sh/sdk-react';
+
+export default function OrgSettingsPage() {
+  return <OrganizationProfile />;
+}
+```
+
+The component reads the user's current `Organization` from the JWT's `org` claim and renders a multi-section panel:
+
+- **General** — organization name, slug, logo.
+- **Members** — current memberships with roles; admin actions (change role, remove member).
+- **Invitations** — pending invitations; create / revoke.
+- **Domains** — verified domain list, enrollment mode (manual / auto-invitation / auto-suggestion), DNS verification flows.
+- **Membership requests** — pending sign-up requests when auto-suggestion is enabled.
+- **Roles** — system + custom roles, permission matrix.
+- **Danger zone** — leave organization, delete organization (when allowed by environment settings).
+
+Sections are gated on the user's permissions — a member with only `org:read` sees the members list but not the admin actions; a non-admin doesn't see the danger zone at all.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `routing` | `'path' \| 'hash' \| 'virtual'` | `'path'` | How the component navigates between sections. |
+| `path` | `string` | `'/organization'` | Base path for `routing: 'path'`. |
+| `afterLeaveOrganizationUrl` | `string` | environment `home_url` | Where to send the user after they leave the organization. |
+| `appearance` | `Appearance` | — | Per-render appearance override. |
+| `localization` | `Localization` | — | Per-render localization override. |
+| `customPages` | `CustomPage[]` | `[]` | Operator-defined extra pages to slot into the section list. |
+
+## Custom pages
+
+Same pattern as `<UserProfile />`:
+
+```tsx
+<OrganizationProfile>
+  <OrganizationProfile.Page
+    label="Billing"
+    url="billing"
+    labelIcon={<CreditCardIcon />}
+  >
+    <OrgBillingSettings />
+  </OrganizationProfile.Page>
+</OrganizationProfile>
+```
+
+## Composition
+
+When you want only a few of the bundled flows (just the members list, say) without the full profile shell, use the underlying hooks:
+
+- `useOrganization()` — current `Organization`, membership list, invitation list.
+- `useOrganizationList()` — every organization the user belongs to.
+- `useOrganizationMembership()` — the current user's `OrganizationMembership` row (with `hasPermission(...)`).
+
+The hooks expose the same surfaces `<OrganizationProfile />` uses internally.

--- a/src/content/docs/sdk/react/components/organization-switcher.md
+++ b/src/content/docs/sdk/react/components/organization-switcher.md
@@ -1,0 +1,53 @@
+---
+title: <OrganizationSwitcher />
+description: A standalone organization picker — switch active org, create new org, accept invitations.
+---
+
+`<OrganizationSwitcher />` renders an inline button + popover that lets the user switch their active `Organization`, create a new one, or accept pending invitations. It's the standalone variant of the org-switcher embedded in [`<UserButton />`](/sdk/react/components/user-button/), suitable for app chrome where the org context is more prominent than the user identity (e.g. a left-rail header in a B2B dashboard).
+
+Available from v1 of `@authn.sh/sdk-react`.
+
+## Quickstart
+
+```tsx
+import { OrganizationSwitcher } from '@authn.sh/sdk-react';
+
+export default function Sidebar() {
+  return (
+    <aside>
+      <OrganizationSwitcher />
+      <nav>{/* … */}</nav>
+    </aside>
+  );
+}
+```
+
+When the user belongs to no organizations, the component renders only the "Create organization" action. When the environment has Organizations disabled, the component renders nothing.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `hidePersonal` | `boolean` | `false` | When `true`, hides the "Personal account" option — useful for B2B products where users must operate within an organization at all times. |
+| `createOrganizationMode` | `'navigation' \| 'modal'` | `'modal'` | `modal` opens an in-place "Create organization" dialog. `navigation` sends the user to `createOrganizationUrl`. |
+| `createOrganizationUrl` | `string` | — | Required when `createOrganizationMode: 'navigation'`. |
+| `afterCreateOrganizationUrl` | `string` | environment `home_url` | Where to send the user after they create a new organization. |
+| `afterSelectOrganizationUrl` | `string` | environment `home_url` | Where to send the user after they switch organizations. |
+| `afterSelectPersonalUrl` | `string` | environment `home_url` | Where to send the user after they switch back to their personal account. |
+| `organizationProfileMode` | `'navigation' \| 'modal'` | `'navigation'` | `navigation` opens `organizationProfileUrl` in the current tab. `modal` opens `<OrganizationProfile />` in an in-place modal. |
+| `organizationProfileUrl` | `string` | `/organization` | Where the **Manage organization** action sends the user. |
+| `appearance` | `Appearance` | — | Per-render appearance override. |
+| `localization` | `Localization` | — | Per-render localization override. |
+
+## Pending invitations
+
+The switcher includes an "Invitations" affordance when the user has unaccepted `OrganizationInvitation` rows. Accepting an invitation from the popover adds the user to the inviting organization and sets it as `active_organization` — no separate accept page required.
+
+## Composition
+
+For finer-grained control, the popover sub-elements are exposed:
+
+- `<OrganizationSwitcher.OrganizationProfilePage />` — slot a custom page into the inline org-profile modal (same surface as `<OrganizationProfile.Page />`).
+- `<OrganizationSwitcher.OrganizationProfileLink />` — slot an inline link into the popover.
+
+When you want the picker logic without the popover chrome, reach for `useOrganizationList()` directly.

--- a/src/content/docs/sdk/react/components/sign-in.md
+++ b/src/content/docs/sdk/react/components/sign-in.md
@@ -1,0 +1,60 @@
+---
+title: <SignIn />
+description: The bundled sign-in flow component — every supported first-factor and second-factor strategy out of the box.
+---
+
+`<SignIn />` renders the complete sign-in flow — identifier entry, strategy picking, OAuth redirects, magic-link / email-code / SMS-code verification, passkey assertion, second-factor prompts — without you wiring any of it. It's the v1 entry-point component you drop into a `/sign-in` page.
+
+Available from v1 of `@authn.sh/sdk-react`.
+
+## Quickstart
+
+```tsx
+import { SignIn } from '@authn.sh/sdk-react';
+
+export default function SignInPage() {
+  return <SignIn />;
+}
+```
+
+The component reads the environment config at mount, surfaces every enabled first-factor strategy (password / email-code / email-link / phone-code / OAuth providers / passkey), drives second-factor challenges (TOTP / backup codes / phone-code) when the user has them, and on success either calls `routing` to navigate the user away or invokes the `afterSignInUrl`.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `routing` | `'path' \| 'hash' \| 'virtual'` | `'path'` | How the component navigates between internal steps. `path` mutates `window.location.pathname`; `hash` mutates the hash; `virtual` keeps everything in-memory (useful when embedded in a modal). |
+| `path` | `string` | `'/sign-in'` | Base path for `routing: 'path'`. The component appends `/factor-one`, `/factor-two`, `/reset-password`, etc. |
+| `signUpUrl` | `string` | — | Where to send users who click the "Sign up" footer link. Defaults to the environment's sign-up URL. |
+| `afterSignInUrl` | `string` | environment `home_url` | Where to send users on successful sign-in. Overridable per-render. |
+| `afterSignUpUrl` | `string` | environment `home_url` | Where to send users who completed a transferable sign-up triggered from this `<SignIn />` (e.g. a magic-link recipient with no existing account). |
+| `redirectUrl` | `string` | the OAuth callback handler | Used as the OAuth `redirect_uri` instead of the canonical environment value. Self-hosters with custom routing topologies use this to keep OAuth callbacks on a stable domain. |
+| `initialValues` | `Partial<SignInFormValues>` | `{}` | Pre-fills the identifier form (e.g. `{ emailAddress: 'user@example.com' }` when you ship users from a prior interstitial). |
+| `appearance` | `Appearance` | — | Per-render appearance override; merged with the per-environment `Environment.appearance` blob. See [Theming](/customization/theming/). |
+| `localization` | `Localization` | — | Per-render localization override; merged with the per-environment `Environment.localization` blob. See [Localization](/customization/localization/). |
+| `transferable` | `boolean` | `true` | When `true`, an email-code / email-link aimed at an address with no existing `User` automatically transfers into a sign-up. Set `false` to refuse transfers (sign-up must happen via `<SignUp />`). |
+| `forceRedirectUrl` | `string` | — | Skips `routing` and forces the post-sign-in redirect to this URL regardless of `afterSignInUrl`. Used by deep-link recovery flows. |
+
+## State
+
+Internal state machine the component walks:
+
+```
+start            → identifier entry, strategy picker
+factor_one       → first-factor verification (password / email-code / magic-link / phone-code / passkey / oauth)
+factor_two       → second-factor prompt (totp / backup-code / phone-code)
+verifying        → strategy verification in flight (e.g. magic-link polling)
+complete         → session minted, redirect imminent
+```
+
+Each state has its own internal page. With `routing: 'path'` the URL reflects the state (`/sign-in/factor-one`, `/sign-in/factor-two`); with `routing: 'virtual'` the user sees a single URL for the whole flow.
+
+## Composition
+
+`<SignIn />` is monolithic by design. If you need to compose individual sub-flows yourself, use the hooks under [`@authn.sh/sdk-react` → hooks](https://github.com/authn-sh/javascript/tree/main/packages/sdk-react):
+
+- `useSignIn()` — drive a sign-in by hand.
+- `useUser()` — current `User` once signed in.
+- `useSession()` — current `Session`.
+
+The hooks expose the same surfaces `<SignIn />` uses internally; everything `<SignIn />` does is reachable from user code.

--- a/src/content/docs/sdk/react/components/sign-up.md
+++ b/src/content/docs/sdk/react/components/sign-up.md
@@ -1,0 +1,55 @@
+---
+title: <SignUp />
+description: The bundled sign-up flow component — identifier entry, verification, optional profile fields, organization invitations.
+---
+
+`<SignUp />` renders the complete sign-up flow — identifier entry, identifier verification (email code / email link / phone code), optional first-name / last-name capture, password / passkey enrollment when required, and the post-sign-up handoff (organization invitation acceptance, automatic active-org selection).
+
+Available from v1 of `@authn.sh/sdk-react`.
+
+## Quickstart
+
+```tsx
+import { SignUp } from '@authn.sh/sdk-react';
+
+export default function SignUpPage() {
+  return <SignUp />;
+}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `routing` | `'path' \| 'hash' \| 'virtual'` | `'path'` | How the component navigates between internal steps. |
+| `path` | `string` | `'/sign-up'` | Base path for `routing: 'path'`. |
+| `signInUrl` | `string` | — | Where to send users who click "Already have an account? Sign in". Defaults to the environment's sign-in URL. |
+| `afterSignUpUrl` | `string` | environment `home_url` | Where to send users on successful sign-up. |
+| `afterSignInUrl` | `string` | environment `home_url` | Used when the sign-up flow transfers into a sign-in (e.g. magic-link recipient who already has an account). |
+| `redirectUrl` | `string` | the OAuth callback handler | OAuth `redirect_uri` override. |
+| `initialValues` | `Partial<SignUpFormValues>` | `{}` | Pre-fills `{ emailAddress, firstName, lastName, phoneNumber }`. |
+| `appearance` | `Appearance` | — | Per-render appearance override. |
+| `localization` | `Localization` | — | Per-render localization override. |
+| `unsafeMetadata` | `Record<string, unknown>` | — | Forwarded as `User.unsafe_metadata` on creation. |
+| `forceRedirectUrl` | `string` | — | Forces the post-sign-up redirect to this URL regardless of `afterSignUpUrl`. |
+
+## State
+
+```
+start         → identifier entry + optional fields
+verifying     → identifier verification in flight (email-code / magic-link / phone-code)
+missing_requirements → environment requires a field the form didn't capture (e.g. password)
+complete      → User created, session minted, redirect imminent
+```
+
+The `missing_requirements` state is the affordance for environments that require, e.g., a password on sign-up. The component renders the missing-field prompt automatically — there's no extra wiring.
+
+## Organization invitations
+
+If a user arrives at `<SignUp />` via an organization invitation link (the `?__authn_ticket=...` query param), the component:
+
+1. Verifies the ticket against `/v1/me/invitations/accept`.
+2. Pre-fills the email field with the invited address and locks editing.
+3. After verification, automatically adds the new `User` to the inviting `Organization` and sets it as `User.active_organization`.
+
+No extra props required — the component reads the ticket from the URL.

--- a/src/content/docs/sdk/react/components/user-button.md
+++ b/src/content/docs/sdk/react/components/user-button.md
@@ -1,0 +1,72 @@
+---
+title: <UserButton />
+description: The avatar + popover that surfaces account actions and an org-switcher from anywhere in your app.
+---
+
+`<UserButton />` renders the current user's avatar with a popover that surfaces "Manage account", "Sign out", a language switcher, and (when Organizations are enabled on the environment) an inline org-switcher. It's the v1 component you drop into the corner of your app's chrome.
+
+Available from v1 of `@authn.sh/sdk-react`.
+
+## Quickstart
+
+```tsx
+import { UserButton } from '@authn.sh/sdk-react';
+
+export default function AppShell({ children }) {
+  return (
+    <div>
+      <nav>
+        <a href="/">Home</a>
+        <UserButton />
+      </nav>
+      {children}
+    </div>
+  );
+}
+```
+
+When the user is signed out, the component renders nothing — you'll typically render a `<Link to="/sign-in">` next to it and let one of the two show at a time.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `afterSignOutUrl` | `string` | environment `home_url` | Where to send the user after they click **Sign out**. |
+| `signInUrl` | `string` | environment sign-in URL | Where to send the user when they don't have an active session (typically used in tandem with `<SignedOut />` to bypass rendering the component itself). |
+| `userProfileUrl` | `string` | `/user` | The route the **Manage account** link points at — wire it to the page that hosts `<UserProfile />`. |
+| `userProfileMode` | `'navigation' \| 'modal'` | `'navigation'` | `navigation` opens `userProfileUrl` in the current tab. `modal` opens `<UserProfile />` in an in-place modal dialog (useful when your app has no dedicated account page). |
+| `showName` | `boolean` | `false` | When `true`, renders the user's name next to the avatar. |
+| `appearance` | `Appearance` | — | Per-render appearance override. |
+| `localization` | `Localization` | — | Per-render localization override. |
+| `defaultOpen` | `boolean` | `false` | Forces the popover open on mount. Useful for product tours / onboarding. |
+
+## Composition
+
+For a custom popover layout, the action rows are exposed:
+
+- `<UserButton.MenuItems />` — full menu list customisation.
+- `<UserButton.Action label="…" labelIcon={…} onClick={…} />` — slot a custom action.
+- `<UserButton.Link label="…" labelIcon={…} href="…" />` — slot a custom link.
+
+```tsx
+<UserButton>
+  <UserButton.MenuItems>
+    <UserButton.Action
+      label="Switch theme"
+      labelIcon={<MoonIcon />}
+      onClick={() => toggleTheme()}
+    />
+    <UserButton.Link
+      label="Help"
+      labelIcon={<HelpIcon />}
+      href="/help"
+    />
+  </UserButton.MenuItems>
+</UserButton>
+```
+
+Custom items render after the bundled rows (Manage account, language picker, theme picker, Sign out).
+
+## Org switcher
+
+When the environment has Organizations enabled, the popover includes an inline org list and a "Create organization" action. Switching organizations changes `User.active_organization` and refreshes the JWT with the new `org` claim. See [`<OrganizationSwitcher />`](/sdk/react/components/organization-switcher/) for a standalone variant when you want the org picker outside the `<UserButton />` chrome.

--- a/src/content/docs/sdk/react/components/user-profile.md
+++ b/src/content/docs/sdk/react/components/user-profile.md
@@ -1,0 +1,68 @@
+---
+title: <UserProfile />
+description: The bundled user-profile component — account settings, email / phone / password / passkey / MFA management, connected accounts, sessions, danger zone.
+---
+
+`<UserProfile />` renders the complete account-settings surface for the currently signed-in user. It's the v1 component you drop into a `/account` route to give your users a place to manage their identity without you having to build any of it.
+
+Available from v1 of `@authn.sh/sdk-react`.
+
+## Quickstart
+
+```tsx
+import { UserProfile } from '@authn.sh/sdk-react';
+
+export default function AccountPage() {
+  return <UserProfile />;
+}
+```
+
+Renders a multi-section panel:
+
+- **Account** — name, profile image, primary email / phone selection.
+- **Security** — password management, passkey enrollment list, TOTP enrollment, backup codes, active sessions.
+- **Connected accounts** — OAuth provider links (add / remove).
+- **Phone numbers** — add / verify / set primary / reserve-for-MFA.
+- **Emails** — add / verify / set primary.
+- **Organizations** — when the environment has Organizations enabled, the user's memberships list.
+- **Danger zone** — delete account (when allowed by environment settings).
+
+The section list adapts to environment configuration — a section disappears if every feature it gates is disabled (no point showing "Passkeys" if the operator disabled passkeys at instance level).
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `routing` | `'path' \| 'hash' \| 'virtual'` | `'path'` | How the component navigates between sections. |
+| `path` | `string` | `'/user'` | Base path for `routing: 'path'`. |
+| `appearance` | `Appearance` | — | Per-render appearance override. |
+| `localization` | `Localization` | — | Per-render localization override. |
+| `additionalOAuthScopes` | `Record<string, string[]>` | `{}` | Per-provider extra scopes to request when the user clicks **Connect**. Useful when the operator wants the OAuth connection to carry app-specific scopes (e.g. `slack: ['channels:read']`). |
+| `customPages` | `CustomPage[]` | `[]` | Operator-defined extra pages to slot into the section list. See [Custom pages](#custom-pages) below. |
+
+## Custom pages
+
+For app-specific account settings (e.g. "Notifications", "Billing") you want to live next to the bundled sections:
+
+```tsx
+<UserProfile>
+  <UserProfile.Page
+    label="Billing"
+    url="billing"
+    labelIcon={<CreditCardIcon />}
+  >
+    <BillingSettings />
+  </UserProfile.Page>
+</UserProfile>
+```
+
+`label`, `url`, `labelIcon` define the sidebar entry. The children render in the right-hand pane when the user navigates to that section. The component handles the routing — your inner component doesn't need to know how it's mounted.
+
+## Composition
+
+For finer-grained control, the section-level subcomponents are exposed:
+
+- `<UserProfile.Section />` — slot a custom section between the bundled ones.
+- `<UserProfile.Page />` — add a wholly new page (as above).
+
+When you want a completely custom account surface and only need a few of the bundled flows (just MFA enrollment, say), reach for the [security components](/reference/security-components/) — they're the same dialogs `<UserProfile />` uses internally and they work standalone.

--- a/src/content/docs/social-providers/discord.md
+++ b/src/content/docs/social-providers/discord.md
@@ -1,0 +1,69 @@
+---
+title: Discord
+description: Configure Discord sign-in as an OAuth preset.
+---
+
+Discord is an OAuth 2.0 preset shipped from v0.5 of authn.sh. Discord doesn't expose OIDC discovery, so the preset is wired as plain OAuth 2.0 with hard-coded endpoints.
+
+## Default scopes
+
+| Scope | Returns |
+| --- | --- |
+| `identify` | Discord `id`, `username`, `discriminator`, `avatar`. |
+| `email` | Verified primary email address. |
+
+Add more scopes per row if you need guild membership / friends list / etc. — they go on the `scopes[]` field of the `OauthProvider` row.
+
+## Register an application on Discord
+
+1. Open the [Discord Developer Portal → Applications](https://discord.com/developers/applications) and click **New Application**.
+2. Name the app (this is what users see at the consent screen) and confirm.
+3. Open **OAuth2 → General**.
+4. Under **Redirects**, paste the `redirect_uri` from your authn.sh `OauthProvider` row — the canonical format is `https://<env_slug>.authn.sh/v1/oauth-callback/discord` (or the equivalent under your self-hosted apex). Save.
+5. Copy **Client ID** and click **Reset Secret** to generate a fresh **Client Secret**. Copy it.
+
+## Configure the provider in authn.sh
+
+Click through **Dashboard → Configure → Authentication → Social providers → Add provider → Discord** and paste the credentials. Or POST via BAPI:
+
+```http
+POST /v1/oauth-providers
+Authorization: Bearer sk_live_…
+Content-Type: application/json
+
+{
+  "provider_kind": "preset",
+  "provider_key": "discord",
+  "name": "Discord",
+  "client_id": "1234567890123456789",
+  "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+}
+```
+
+## `attribute_mapping`
+
+The preset ships with sensible defaults — no override needed for the common case:
+
+| authn.sh field | Discord claim |
+| --- | --- |
+| `email_address` | `email` |
+| `first_name` | `username` |
+| `provider_user_id` | `id` |
+| `profile_image_url` | `avatar` (the SDK rewrites it to the full CDN URL) |
+
+If you'd rather use the Discord global display name as `first_name`, override `attribute_mapping`:
+
+```json
+{
+  "attribute_mapping": {
+    "email_address": "email",
+    "first_name": "global_name",
+    "provider_user_id": "id"
+  }
+}
+```
+
+## Notes
+
+- Discord requires the user's primary email to be **verified** before it surfaces it on the userinfo response. authn.sh trusts this — accounts created via Discord land with `email_address.verified: true`.
+- Discord's userinfo response is paginated only for friends / guilds. The basic `identify` + `email` payload comes back in a single call.

--- a/src/content/docs/social-providers/facebook.md
+++ b/src/content/docs/social-providers/facebook.md
@@ -1,0 +1,57 @@
+---
+title: Facebook
+description: Configure Facebook (Meta) sign-in as an OAuth preset.
+---
+
+Facebook is an OAuth 2.0 preset shipped from v0.5 of authn.sh. Facebook ships custom userinfo semantics — the `/me` endpoint requires an explicit `fields` query parameter to surface email + name. authn.sh's preset handles that for you.
+
+## Default scopes
+
+| Scope | Returns |
+| --- | --- |
+| `public_profile` | Facebook user `id`, `name`, `first_name`, `last_name`, `picture`. |
+| `email` | Primary email address (verified). |
+
+## Register an application on Meta
+
+1. Open [Meta for Developers → My Apps](https://developers.facebook.com/apps/) and click **Create App**.
+2. Pick **Consumer** as the use case (or **Business** if you need advanced permissions). Name the app and confirm.
+3. Inside the app, under **Add products to your app**, add **Facebook Login**.
+4. In **Facebook Login → Settings**, paste the `redirect_uri` from your authn.sh `OauthProvider` row — `https://<env_slug>.authn.sh/v1/oauth-callback/facebook` — into **Valid OAuth Redirect URIs**. Save.
+5. In **App settings → Basic**, copy **App ID** (this is the `client_id`) and **App Secret** (this is the `client_secret` — click **Show**, you may need to re-enter your Facebook password).
+
+## Configure the provider in authn.sh
+
+```http
+POST /v1/oauth-providers
+Authorization: Bearer sk_live_…
+Content-Type: application/json
+
+{
+  "provider_kind": "preset",
+  "provider_key": "facebook",
+  "name": "Facebook",
+  "client_id": "1234567890123456",
+  "client_secret": "your-facebook-app-secret-here"
+}
+```
+
+## `attribute_mapping`
+
+Preset defaults — no override needed for the common case:
+
+| authn.sh field | Facebook claim |
+| --- | --- |
+| `email_address` | `email` |
+| `first_name` | `first_name` |
+| `last_name` | `last_name` |
+| `provider_user_id` | `id` |
+| `profile_image_url` | `picture.data.url` |
+
+Note `picture.data.url` — Facebook returns the avatar as a nested object, not a top-level URL. authn.sh's `attribute_mapping` understands dot-paths so the default works out of the box.
+
+## Notes
+
+- Facebook only surfaces `email` if the user granted the `email` permission **and** their Facebook account has a verified email. If the user has no verified email, `email_address` lands as `null` and the FAPI rejects the sign-up with `oauth_no_email_returned` — you'll want a fallback flow (email-code / password) for those users, or set `allow_sign_up: false` on the Facebook row so they fall back to an existing-account sign-in.
+- Facebook's app review process gates `public_profile` past the development phase. While your app is in development mode, only Meta accounts you've added as developers / testers can sign in. Submit for review when you're ready to ship.
+- The `picture.data.url` Facebook returns is a short-lived URL pointing at their CDN. authn.sh re-fetches and re-hosts the avatar on first sign-in so the link doesn't decay.

--- a/src/content/docs/social-providers/gitlab.md
+++ b/src/content/docs/social-providers/gitlab.md
@@ -1,0 +1,79 @@
+---
+title: GitLab
+description: Configure GitLab sign-in as an OIDC preset.
+---
+
+GitLab is an OIDC preset shipped from v0.5 of authn.sh. GitLab.com exposes OIDC discovery; the preset points at `https://gitlab.com/.well-known/openid-configuration` by default, but self-managed GitLab instances are supported via the `custom_oidc` kind (see below).
+
+## Default scopes
+
+| Scope | Returns |
+| --- | --- |
+| `openid` | Required by OIDC. |
+| `profile` | GitLab `sub`, `name`, `nickname`, `preferred_username`, `picture`. |
+| `email` | Email + `email_verified`. |
+
+## Register an application on GitLab
+
+1. Open [GitLab → User Settings → Applications](https://gitlab.com/-/profile/applications) (for personal apps) or your group's **Settings → Applications** for a group-owned app.
+2. Click **Add new application**.
+3. Fill in:
+   - **Name**: anything (this is what users see at consent).
+   - **Redirect URI**: paste the `redirect_uri` from your authn.sh `OauthProvider` row — `https://<env_slug>.authn.sh/v1/oauth-callback/gitlab`.
+   - **Confidential**: yes (GitLab calls a server-side app "confidential").
+   - **Scopes**: tick `openid`, `profile`, `email`.
+4. Click **Save application**. Copy the **Application ID** (this is the `client_id`) and the **Secret** (this is the `client_secret`).
+
+## Configure the provider in authn.sh
+
+```http
+POST /v1/oauth-providers
+Authorization: Bearer sk_live_…
+Content-Type: application/json
+
+{
+  "provider_kind": "preset",
+  "provider_key": "gitlab",
+  "name": "GitLab",
+  "client_id": "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1",
+  "client_secret": "your-gitlab-application-secret-here"
+}
+```
+
+## `attribute_mapping`
+
+Preset defaults — no override needed for the common case:
+
+| authn.sh field | GitLab claim |
+| --- | --- |
+| `email_address` | `email` |
+| `first_name` | `given_name` (falls back to `name` if absent) |
+| `last_name` | `family_name` |
+| `provider_user_id` | `sub` |
+| `profile_image_url` | `picture` |
+
+## Self-managed GitLab
+
+If you're pointing at a self-managed GitLab (`gitlab.acme.com`) instead of GitLab.com, register the provider as `custom_oidc` rather than `preset` and set the issuer to your instance's base URL:
+
+```http
+POST /v1/oauth-providers
+Authorization: Bearer sk_live_…
+Content-Type: application/json
+
+{
+  "provider_kind": "custom_oidc",
+  "provider_key": "gitlab_acme",
+  "name": "Acme GitLab",
+  "client_id": "...",
+  "client_secret": "...",
+  "issuer": "https://gitlab.acme.com"
+}
+```
+
+The server fetches `https://gitlab.acme.com/.well-known/openid-configuration` and populates the OIDC endpoints automatically. See the [Custom OIDC walkthrough](/guides/custom-oidc/) for the full flow.
+
+## Notes
+
+- GitLab returns `email_verified: true` for every email surfaced via the userinfo endpoint — they only release verified addresses.
+- If your users sign in with both GitLab.com and a self-managed instance, they're two separate `OauthProvider` rows with two separate `ExternalAccount` links per user. There's no shared identity between them.

--- a/src/content/docs/social-providers/linkedin.md
+++ b/src/content/docs/social-providers/linkedin.md
@@ -1,0 +1,55 @@
+---
+title: LinkedIn
+description: Configure LinkedIn sign-in as an OIDC preset.
+---
+
+LinkedIn is an OIDC preset shipped from v0.5 of authn.sh. LinkedIn exposes the standard OIDC discovery document, so the preset is wired as `custom_oidc` under the hood with the issuer auto-resolved.
+
+## Default scopes
+
+| Scope | Returns |
+| --- | --- |
+| `openid` | Required by OIDC. |
+| `profile` | LinkedIn `sub` (user id), `name`, `given_name`, `family_name`, `picture`. |
+| `email` | Email + `email_verified`. |
+
+## Register an application on LinkedIn
+
+1. Open [LinkedIn Developers → My Apps](https://www.linkedin.com/developers/apps) and click **Create app**.
+2. Fill out the form (app name, associated company page, app logo). Confirm.
+3. Open **Products** and add **Sign In with LinkedIn using OpenID Connect**. Approval is usually immediate.
+4. Open **Auth** → **OAuth 2.0 settings**. Paste the `redirect_uri` from your authn.sh `OauthProvider` row — `https://<env_slug>.authn.sh/v1/oauth-callback/linkedin` — into **Authorized redirect URLs for your app**. Save.
+5. Copy **Client ID** and **Client Secret** from the same screen.
+
+## Configure the provider in authn.sh
+
+```http
+POST /v1/oauth-providers
+Authorization: Bearer sk_live_…
+Content-Type: application/json
+
+{
+  "provider_kind": "preset",
+  "provider_key": "linkedin",
+  "name": "LinkedIn",
+  "client_id": "861234567890ab",
+  "client_secret": "your-linkedin-client-secret-here"
+}
+```
+
+## `attribute_mapping`
+
+Preset defaults — no override needed for the common case:
+
+| authn.sh field | LinkedIn claim |
+| --- | --- |
+| `email_address` | `email` |
+| `first_name` | `given_name` |
+| `last_name` | `family_name` |
+| `provider_user_id` | `sub` |
+| `profile_image_url` | `picture` |
+
+## Notes
+
+- LinkedIn returns `email_verified: true` for every email surfaced via the OIDC userinfo endpoint — they only return the user's primary, verified address.
+- The legacy "Sign In with LinkedIn v1" product (non-OIDC) is **not** what this preset uses; make sure the **OpenID Connect** variant is added to your LinkedIn app, otherwise the discovery document won't resolve and the test button returns `oauth_discovery_failed`.

--- a/src/content/docs/social-providers/slack.md
+++ b/src/content/docs/social-providers/slack.md
@@ -1,0 +1,90 @@
+---
+title: Slack
+description: Configure "Sign in with Slack" as an OIDC preset.
+---
+
+Slack is an OIDC preset shipped from v0.5 of authn.sh. Slack exposes the standard OIDC discovery document under "Sign in with Slack", so the preset is wired as `custom_oidc` under the hood with the issuer auto-resolved to `https://slack.com`.
+
+## Default scopes
+
+| Scope | Returns |
+| --- | --- |
+| `openid` | Required by OIDC. |
+| `profile` | Slack `sub`, `name`, `given_name`, `family_name`, `picture`, `https://slack.com/team_id`, `https://slack.com/team_name`. |
+| `email` | Email + `email_verified`. |
+
+## "Sign in with Slack" vs "Add to Slack"
+
+Slack has two OAuth surfaces:
+
+- **Sign in with Slack** — OIDC-shaped, returns user identity claims. This is the one this preset uses.
+- **Add to Slack** — installs your app as a Slack workspace integration. Different scopes (`channels:read`, `chat:write`, …), different endpoint. Not relevant to authn.sh.
+
+If you need both (auth + a Slack bot), keep them in separate Slack apps so the scope sets don't entangle.
+
+## Register an application on Slack
+
+1. Open the [Slack API → Your Apps](https://api.slack.com/apps) page and click **Create New App** → **From scratch**.
+2. Name the app, pick a development workspace, confirm.
+3. In the app settings, open **OAuth & Permissions**.
+4. Under **Redirect URLs**, click **Add New Redirect URL**, paste the `redirect_uri` from your authn.sh `OauthProvider` row — `https://<env_slug>.authn.sh/v1/oauth-callback/slack` — and save.
+5. Scroll down to **User Token Scopes** and add `openid`, `profile`, `email`.
+6. From **Basic Information** → **App Credentials**, copy **Client ID** and **Client Secret**.
+
+## Configure the provider in authn.sh
+
+```http
+POST /v1/oauth-providers
+Authorization: Bearer sk_live_…
+Content-Type: application/json
+
+{
+  "provider_kind": "preset",
+  "provider_key": "slack",
+  "name": "Slack",
+  "client_id": "1234567890123.5678901234567",
+  "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+}
+```
+
+## `attribute_mapping`
+
+Preset defaults — no override needed for the common case:
+
+| authn.sh field | Slack claim |
+| --- | --- |
+| `email_address` | `email` |
+| `first_name` | `given_name` |
+| `last_name` | `family_name` |
+| `provider_user_id` | `sub` |
+| `profile_image_url` | `picture` |
+
+## Workspace metadata
+
+Slack ships the user's workspace as custom claims:
+
+- `https://slack.com/team_id` — the Slack workspace's stable identifier.
+- `https://slack.com/team_name` — the workspace's human name.
+
+If you want to pin authn.sh `Organization` membership to the Slack workspace, expose these claims via `attribute_mapping` and use them in your post-callback hook:
+
+```json
+{
+  "attribute_mapping": {
+    "email_address": "email",
+    "first_name": "given_name",
+    "last_name": "family_name",
+    "provider_user_id": "sub",
+    "profile_image_url": "picture",
+    "public_metadata.slack_team_id": "https://slack.com/team_id",
+    "public_metadata.slack_team_name": "https://slack.com/team_name"
+  }
+}
+```
+
+The `public_metadata.*` mapping syntax writes the value onto `User.public_metadata` at sign-up, where your backend can read it from the JWT and slot the user into the right `Organization`.
+
+## Notes
+
+- Slack OIDC returns one identity per (user × workspace). The same human signing in from two workspaces lands as two `ExternalAccount` rows under the same `User` if the email matches, or two `User`s if the emails are different.
+- Slack returns `email_verified: true` for every email surfaced — they only release the user's verified primary.

--- a/src/content/docs/social-providers/x.md
+++ b/src/content/docs/social-providers/x.md
@@ -1,0 +1,66 @@
+---
+title: X (formerly Twitter)
+description: Configure X sign-in as an OAuth 2.0 + PKCE preset.
+---
+
+X (formerly Twitter) is an OAuth 2.0 + PKCE preset shipped from v0.5 of authn.sh. X requires PKCE for every authorization code grant — the preset enables it automatically; you don't need to flip anything.
+
+## Default scopes
+
+| Scope | Returns |
+| --- | --- |
+| `tweet.read` | Required by X's OAuth 2.0 surface even when you don't actually read tweets. |
+| `users.read` | The user's profile (`id`, `username`, `name`, `profile_image_url`). |
+
+## Email is not available
+
+X **does not** expose the user's email via its OAuth 2.0 surface. The preset doesn't request `email` because X doesn't have a corresponding scope. This has two practical consequences:
+
+- The userinfo response carries no `email` field. authn.sh creates the `User` with `email_address: null` and treats `provider_user_id` as the primary identifier.
+- If your environment requires email on sign-up (the default `attributes.email_address.required: true` setting), X sign-ups will fail with `oauth_no_email_returned`. To allow X sign-ups, either flip `email_address.required` to `false` on the environment, or set `allow_sign_up: false` on the X provider row and use it for **linking** existing accounts (sign-in-only).
+
+If you need email, point users at the standard email-code flow on first visit and let them link X afterwards via `<UserProfile />`.
+
+## Register an application on X
+
+1. Open the [X Developer Portal](https://developer.twitter.com/en/portal/dashboard) and create (or open) a Project.
+2. Add an App inside the Project. Under **User authentication settings**:
+   - **Type of App**: Web App.
+   - **App permissions**: Read.
+   - **Callback URI**: paste the `redirect_uri` from your authn.sh `OauthProvider` row — `https://<env_slug>.authn.sh/v1/oauth-callback/x`.
+   - **Website URL**: your app's public URL.
+   - Save.
+3. From **Keys and tokens** → **OAuth 2.0 Client ID and Client Secret**, copy both.
+
+## Configure the provider in authn.sh
+
+```http
+POST /v1/oauth-providers
+Authorization: Bearer sk_live_…
+Content-Type: application/json
+
+{
+  "provider_kind": "preset",
+  "provider_key": "x",
+  "name": "X",
+  "client_id": "QzlxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxQ",
+  "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+}
+```
+
+## `attribute_mapping`
+
+Preset defaults — no override needed for the common case:
+
+| authn.sh field | X claim |
+| --- | --- |
+| `provider_user_id` | `data.id` |
+| `first_name` | `data.name` |
+| `profile_image_url` | `data.profile_image_url` |
+
+`email_address` is intentionally unmapped because X does not surface it.
+
+## Notes
+
+- PKCE is enforced server-side. The preset generates a `code_verifier`, hashes it into `code_challenge: S256`, includes it on the `/authorize` redirect, and posts the verifier back on the token exchange. You don't configure this; it's automatic.
+- X's userinfo response is nested under a `data` key. The default `attribute_mapping` paths reflect that.


### PR DESCRIPTION
Closes #13.

The v0.5 docs sweep. Drafted against the now-merged OA-1..OA-7 OpenAPI specs (openapi #66-#72).

## New pages

### Concepts
- **Passkeys** (`concepts/passkeys.md`) — `Passkey` resource shape (public surface vs server-side credential bytes), WebAuthn registration ceremony (begin / complete + `PasskeyCreationOptions`), sign-in (assertion) ceremony, the four `passkey_*` error codes, RP-ID + origin allowlist guidance for self-hosters, recovery flows.

### Customization
- **Theming** (`customization/theming.md`) — full `Appearance` shape (variables / elements / layout), token + element-key catalogues, dashboard editor + `PATCH /v1/instance/appearance` semantics, client-side `appearance` prop deep-merge semantics, four recipes.
- **Localization** (`customization/localization.md`) — four-source resolution order, the five shipped locales, the `Localization` shape, dashboard editor, the public CORS-open `GET /v1/localization/{locale}` with `Cache-Control` + `ETag` guidance, `{variable}` + `{count, plural, …}` syntax, adding a new locale via `supported_locales[]` + override blob.

### Social providers (six new)
One MDX page per provider — `social-providers/{discord,facebook,linkedin,x,gitlab,slack}.md`. Each covers IdP-side app registration, default scopes, the `attribute_mapping` defaults, and provider-specific footguns (Facebook's nested `picture.data.url`, X's missing `email`, Slack's "Sign in with Slack" vs "Add to Slack", self-managed GitLab via `custom_oidc`).

### React components (v1)
Final prop reference under `sdk/react/components/` for `<SignIn />`, `<SignUp />`, `<UserProfile />`, `<UserButton />`, `<OrganizationProfile />`, `<OrganizationSwitcher />`. Each covers props, internal state machine, custom-page slots, and composition hooks.

## Changed pages

- **Concepts → Webhooks** — event-type catalogue extended with the v0.4 events (`oauthProvider.*`, `externalAccount.*`, `phoneNumber.*`, `smsTemplate.*`) and the v0.5 events (`passkey.added`, `passkey.removed`, `instance.config.appearance_updated`, `localization.updated`). The two configuration events carry a `{ previous, current, diff }` triple so audit handlers can replay the change.
- **Sidebar** (`astro.config.mjs`) — new top-level **Customization**, **Social providers**, and **React components** sections. The Concepts section gets a **Passkeys** entry.
- **CHANGELOG** — v0.5.0 entry in the existing v0.4 format.

## REST reference

`reference/rest.md` is regenerated from the openapi bundle at build time. The v0.5 schemas (`Passkey`, `PasskeyCreationOptions`, `PasskeyRequestOptions`, `PasskeyAttestation`, `PasskeyAssertion`, `Appearance`, `Localization`, `LocalizationUpdateRequest`) and paths (FAPI passkey CRUD + ceremony, FAPI sign-in passkey strategy, BAPI `/v1/instance/appearance` + `/v1/instance/localization`, public CORS `/v1/localization/{locale}`, six new preset `provider_key` values on `OauthProvider.yaml`) will appear in the rebuild against `main` after this merges.

## Verification

- `npm run build` — clean, 43 pages built, no broken-link warnings.

## Merge timing

Per the assignment, **do not merge yet** — DC-1 is held until all v0.5 feature implementations (AU-* / JS-* / PHP-*) have landed, so the docs don't go stale on links into shipped behaviour. Squash-merging once team-lead signals all feature PRs are in.