### PR TITLE
feat(dc-1): add v0.7 docs — OAuth provider mode + JWT templates + Authorized apps + SCIM admin BAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.7.0] — 2026-05-12
+
+### Added
+
+- **OAuth provider mode** — new top-level **OAuth provider mode** section under Concepts covering the conceptual model (`OauthApplication` + `AuthorizationGrant` resources, the five new FAPI endpoints — `/oauth/authorize`, `/oauth/token`, `/oauth/token_info`, `/oauth/userinfo`, `/.well-known/openid-configuration`), the registration walkthrough (operator dashboard wizard — public vs confidential clients, strict redirect-URI matching, scope registration, consent-screen config, client-secret rotation contract), the canonical authorization-code grant flow (RFC 6749 §4.1 + OIDC §3.1.2.1 trace, refresh-token rotation, RFC 6749 §4.1.2.1 error codes), PKCE for public clients (mandatory `code_challenge_method=S256`, length / alphabet bounds, generation snippets for JS / Python), and the discovery endpoint + JWKS (full document shape, supported scopes / grants / claims, `oidc-client-ts` / NextAuth / `requests-oauthlib` consumer recipes, why client libraries should always read discovery rather than hard-code endpoints).
+- **Concepts → JWT templates** — the `JwtTemplate` resource (claims as Liquid expressions over the User / Session / Organization / org_memberships snapshots, `lifetime_seconds` 60..86400, `allowed_clock_skew_seconds` 0..60, RS256 / ES256 / HS256 signing, optional write-only `custom_signing_key` with per-template JWKS at `/.well-known/jwt-template-jwks/<name>.json`), the Liquid placeholder reference (`user.*` minus `private_metadata`, `session.*`, `session.active_organization*`, `org_memberships[]`, built-in filters + `date_unix` / `urlencode` helpers), the always-stamped standard claims (`iss`, `iat`, `exp`, `nbf`, `aud`, `jti`), SDK consumption via `getToken({ template: <name> })`, and lifetime + clock-skew tradeoffs.
+- **Guides → SCIM admin via BAPI** — the v0.6 carryover now live. Issue / list / revoke SCIM tokens programmatically via `$authn->organizations()->scimTokens()` (and the matching JS shape), per-org `ScimAttributeMapping` `PUT` override, a full onboarding-flow worked example, a 90-day rotation cron pattern, the BAPI / FAPI surface distinction via `event.meta.surface`, and the no-permission-gate auth model with scoped BAPI keys as the per-engineer audit-trail option.
+- **`<UserProfile />` reference** — new **Authorized apps** section documenting the third-party `OauthApplication` consent-grant list, what's surfaced per entry (name + homepage, granted scopes, `granted_at` / `last_used_at`), the auto-hide rules, the hard-delete-on-revoke contract, and the `<UserProfile.AuthorizedApps />` subcomponent for relocating the section onto a dedicated `/integrations` page.
+
+### Changed
+
+- **Webhooks concept** — event-type catalogue extended with the v0.7 events (`jwtTemplate.{created,updated,deleted}` with `custom_signing_key` stripped; `oauthApplication.{created,updated,deleted}` with `client_secret` stripped; `authorizationGrant.{granted,revoked}` with `meta.surface` distinguishing user-driven from operator-driven revocation).
+- **REST reference** auto-rebuilt against the v0.7 OpenAPI bundle: BAPI `/v1/jwt-templates` CRUD + `/v1/users/{user_id}/jwt-templates/{name}/tokens` backend-issuance path; BAPI `/v1/oauth-applications` CRUD + `/rotate-secret` + per-app `authorization-grants` admin view; BAPI SCIM admin mirror (`/v1/organizations/{org_id}/scim/*`) closing the v0.6 deferral; BAPI `/v1/enterprise-accounts` spec backfill; FAPI OAuth provider mode endpoints (`/oauth/authorize`, `/oauth/token`, `/oauth/token_info`, `/oauth/userinfo`, `/.well-known/openid-configuration`); FAPI `/v1/me/oauth-authorization-grants` user-scoped view.
+- Sidebar reorganized — new top-level **OAuth provider mode** section listing the five new pages; **Concepts** adds JWT templates; **SCIM 2.0** adds the BAPI walkthrough.
+
 ## [0.6.0] — 2026-05-11
 
 ### Added

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -42,7 +42,18 @@ export default defineConfig({
                         { label: 'Passkeys', slug: 'concepts/passkeys' },
                         { label: 'Enterprise SSO', slug: 'concepts/enterprise-sso' },
                         { label: 'SCIM attribute mapping', slug: 'concepts/scim-attribute-mapping' },
+                        { label: 'JWT templates', slug: 'concepts/jwt-templates' },
                         { label: 'Webhooks', slug: 'concepts/webhooks' },
+                    ],
+                },
+                {
+                    label: 'OAuth provider mode',
+                    items: [
+                        { label: 'Overview', slug: 'concepts/oauth-provider/overview' },
+                        { label: 'Registering an application', slug: 'concepts/oauth-provider/registering-an-application' },
+                        { label: 'Authorization-code flow', slug: 'concepts/oauth-provider/authorization-code-flow' },
+                        { label: 'PKCE for public clients', slug: 'concepts/oauth-provider/pkce' },
+                        { label: 'Discovery + JWKS', slug: 'concepts/oauth-provider/discovery' },
                     ],
                 },
                 {
@@ -71,6 +82,7 @@ export default defineConfig({
                         { label: 'Azure AD / Entra ID', slug: 'guides/scim/azure-ad' },
                         { label: 'Google Workspace', slug: 'guides/scim/google-workspace' },
                         { label: 'Rippling', slug: 'guides/scim/rippling' },
+                        { label: 'SCIM admin via BAPI', slug: 'guides/scim/admin-bapi' },
                     ],
                 },
                 {

--- a/src/content/docs/concepts/jwt-templates.md
+++ b/src/content/docs/concepts/jwt-templates.md
@@ -1,0 +1,172 @@
+---
+title: JWT templates
+description: Substitute a custom JWT shape for the default authn.sh session token — claims, lifetime, allowed clock skew, custom signing keys, Liquid placeholder reference.
+---
+
+A **`JwtTemplate`** lets an operator define a custom JWT shape that the SDK issues in place of the default session token. Custom claims, custom lifetime, custom signing key. Available from v0.7.
+
+You reach for a template when an upstream service expects a specific token shape — a feature-flagging service wanting a `tier` claim, a billing service wanting `customer_id`, a legacy backend wanting its old `sub: <int>` schema rather than `user_…` ULIDs. Instead of rewriting that upstream service, you mint a JWT-template that produces a token it already knows how to verify.
+
+For the default session-token claims (what you get without a template), see [JWT claims](/reference/jwt-claims/).
+
+## The resource
+
+```json
+{
+  "id": "jtmpl_01J8Z…",
+  "object": "jwt_template",
+  "name": "feature-flag",
+  "claims": {
+    "sub": "{{user.id}}",
+    "email": "{{user.primary_email_address.email_address}}",
+    "tier": "{{user.public_metadata.tier | default: 'free'}}",
+    "org_id": "{{session.active_organization.id}}",
+    "org_role": "{{session.active_organization_role.key}}"
+  },
+  "lifetime_seconds": 600,
+  "allowed_clock_skew_seconds": 5,
+  "signing_algorithm": "RS256",
+  "custom_signing_key": null,
+  "created_at": 1715140000000,
+  "updated_at": 1715140000000
+}
+```
+
+The fields:
+
+- **`name`** — the identifier the SDK passes to `getToken({ template: 'feature-flag' })`. Unique per environment.
+- **`claims`** — a JSON object of claim names mapped to **Liquid template** expressions. The server resolves the Liquid against the current snapshot of the User / Session / Organization on each `getToken` call.
+- **`lifetime_seconds`** — how long the issued token is valid. Bounded by `60 <= n <= 86400` (1 minute to 1 day).
+- **`allowed_clock_skew_seconds`** — how much skew the receiving service is expected to tolerate. Surfaced into the `nbf` claim (`iat - allowed_clock_skew_seconds`). Bounded by `0 <= n <= 60`.
+- **`signing_algorithm`** — `RS256`, `ES256`, or `HS256`. `RS256` / `ES256` (asymmetric) use the env's JWKS unless `custom_signing_key` is set. `HS256` requires a `custom_signing_key`.
+- **`custom_signing_key`** — write-only PEM string. Optional. When set, the template is signed with this key instead of the env's primary signing key. Useful for upstream services that want a shared secret rather than verifying against your JWKS.
+
+## Liquid placeholder reference
+
+Template claims are evaluated by a sandboxed Liquid engine — no I/O, no untrusted code execution, no eval. The objects you can reach from inside a `{{ … }}` expression:
+
+### `user`
+
+The signed-in user — same shape as the `User` REST resource.
+
+| Path | Value |
+| --- | --- |
+| `user.id` | `user_01HKX9…` |
+| `user.first_name` | string or empty |
+| `user.last_name` | string or empty |
+| `user.username` | string or empty (env config-dependent) |
+| `user.profile_image_url` | string |
+| `user.primary_email_address.email_address` | string — already-verified email if available |
+| `user.primary_email_address.verified` | boolean |
+| `user.primary_phone_number.phone_number` | E.164 |
+| `user.public_metadata.<key>` | any JSON value the operator wrote |
+| `user.unsafe_metadata.<key>` | any JSON value the user wrote (don't trust on the receiving side) |
+| `user.external_accounts[]` | array — `provider`, `provider_key`, `provider_user_id`, `email_address` |
+| `user.created_at` | ms-epoch |
+
+`user.private_metadata` is **deliberately not exposed** — JWT templates run on the FAPI server, and `private_metadata` is BAPI-only by design.
+
+### `session`
+
+The current session.
+
+| Path | Value |
+| --- | --- |
+| `session.id` | `sess_01HKX9…` |
+| `session.created_at` | ms-epoch |
+| `session.last_active_at` | ms-epoch |
+| `session.expire_at` | ms-epoch — the absolute session expiry, not the token expiry |
+| `session.active_organization.id` | `org_…` or empty |
+| `session.active_organization.slug` | string |
+| `session.active_organization.name` | string |
+| `session.active_organization_role.key` | `org:admin`, `org:member`, … |
+| `session.active_organization_role.permissions[]` | list of permission keys |
+
+### `org_memberships`
+
+When the env has Organizations enabled, the full membership list — useful when you want the receiving service to see every org the user is in, not just the active one.
+
+```liquid
+{
+  "orgs": [
+    {%- for m in org_memberships -%}
+      { "id": "{{m.organization.id}}", "role": "{{m.role.key}}" }{% unless forloop.last %},{% endunless %}
+    {%- endfor -%}
+  ]
+}
+```
+
+### Built-in filters
+
+The standard Liquid filters apply: `default`, `downcase`, `upcase`, `replace`, `split`, `truncate`, `size`, `first`, `last`, `json`, plus the OAuth-spec-shaped helpers `date_unix` (for ms-epoch → seconds conversion) and `urlencode`.
+
+A worked example:
+
+```liquid
+{
+  "sub":           "{{user.id}}",
+  "iss":           "https://example.authn.sh",
+  "iat":           "{{session.last_active_at | date_unix}}",
+  "email":         "{{user.primary_email_address.email_address | downcase}}",
+  "tier":          "{{user.public_metadata.tier | default: 'free'}}",
+  "is_admin":      "{{session.active_organization_role.key == 'org:admin'}}",
+  "feature_flags": "{{user.public_metadata.flags | default: '[]' | json}}"
+}
+```
+
+## Standard claims authn.sh always sets
+
+Whatever you write in `claims`, the server stamps these on top:
+
+- `iss` — the env's issuer URL (`https://<env_slug>.authn.sh`). If you set `iss` in `claims`, your value wins.
+- `iat` — issued-at (token mint time, not session activity time). Always set by the server. Setting it in `claims` is a no-op.
+- `exp` — `iat + lifetime_seconds`. Always set.
+- `nbf` — `iat - allowed_clock_skew_seconds`. Always set.
+- `aud` — defaults to the env's issuer URL. Override by setting `aud` in `claims`.
+- `jti` — random ULID, always set, prevents replay.
+
+## Using a template from the SDK
+
+```typescript
+import { useAuth } from '@authn-sh/sdk-react';
+
+function Component() {
+  const { getToken } = useAuth();
+
+  const callBilling = async () => {
+    const token = await getToken({ template: 'billing-service' });
+    await fetch('https://billing.acme.example/charge', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  };
+  // ...
+}
+```
+
+The SDK caches the issued token for the template's `lifetime_seconds` minus a 10% safety margin, then re-mints on demand. Multiple calls in quick succession get the same cached token; calls after expiry mint fresh.
+
+For backend issuance (no browser session — server-to-server, you have a `user_id` but no session ticket), use the BAPI `POST /v1/users/{user_id}/jwt-templates/{name}/tokens` endpoint. Same template, no session-scoped claims (`session.*` resolve to null).
+
+## Lifetime + clock-skew considerations
+
+Three knobs worth thinking about together:
+
+- **`lifetime_seconds`** — shorter tokens are safer if they leak, but they require more `getToken` round-trips. The SDK absorbs that for in-browser code; backends should cache.
+- **`allowed_clock_skew_seconds`** — receivers usually tolerate 30-60s of clock drift. Setting `nbf` slightly in the past avoids "token not yet valid" errors when the issuing FAPI server and the receiving service disagree on the current second.
+- **The combination** — for a service that's strict about `nbf`, set `allowed_clock_skew_seconds: 30`; for a service that strictly enforces `exp` with no leeway, give yourself extra `lifetime_seconds` so the SDK has time to re-mint.
+
+## Custom signing keys
+
+By default, the template uses the env's primary signing key — the same one verifying the env's session tokens. Receiving services verify against `https://<env_slug>.authn.sh/.well-known/jwks.json`.
+
+For an upstream service that wants a **shared secret** (HS256) rather than dealing with JWKS rotation, set `custom_signing_key` to the secret string. The template is then signed with that key, and the upstream service verifies with the same key it has locally. This is useful for legacy backends but counts against rotation hygiene — rotating the shared secret means coordinating with every receiver. Prefer RS256 + JWKS when you can.
+
+For an asymmetric custom signing key (you want this template to sign with a key separate from the env's main JWKS), set `custom_signing_key` to a PEM-encoded private key. The matching public-key JWKS for the template is surfaced at `GET /.well-known/jwt-template-jwks/<template-name>.json` so receivers can fetch and cache it independently.
+
+## Webhook events
+
+JWT-template lifecycle fires the standard webhook trio: `jwtTemplate.created`, `jwtTemplate.updated`, `jwtTemplate.deleted`. The `custom_signing_key` is **stripped** from all three event payloads — the same write-only contract that applies to GETs.
+
+## Reference
+
+REST CRUD lives at `BAPI /v1/jwt-templates`. See the [REST API reference](/reference/rest/#jwt-templates-bapi) for the full endpoint table.

--- a/src/content/docs/concepts/oauth-provider/authorization-code-flow.md
+++ b/src/content/docs/concepts/oauth-provider/authorization-code-flow.md
@@ -1,0 +1,187 @@
+---
+title: Authorization-code grant flow
+description: Step-by-step trace of /oauth/authorize → consent → /oauth/token — the canonical RFC 6749 §4.1 + OIDC §3.1.2.1 flow as authn.sh implements it.
+---
+
+The authorization-code grant is the flow third-party apps use to obtain tokens on behalf of a user. authn.sh implements RFC 6749 §4.1 + OIDC §3.1.2.1 exactly — no proprietary deviations. Available from v0.7.
+
+This page traces one canonical flow end-to-end. For PKCE specifics (mandatory for public clients), see [PKCE for public clients](/concepts/oauth-provider/pkce/).
+
+## Cast
+
+- **Acme** — a third-party app. Has registered an `OauthApplication` with `client_id: oac_pub_AbC123`, `client_secret: oac_sec_xy7…`, `redirect_uris: ["https://acme.example/oauth/callback"]`, scopes `["openid", "profile", "email"]`.
+- **Brian** — an end-user, signed in (or not) to the example env `https://example.authn.sh`.
+- **example.authn.sh** — the authn.sh env acting as the IdP.
+
+## Step 1 — Acme redirects Brian to /oauth/authorize
+
+Acme's frontend builds the URL:
+
+```
+https://example.authn.sh/oauth/authorize
+  ?response_type=code
+  &client_id=oac_pub_AbC123
+  &redirect_uri=https%3A%2F%2Facme.example%2Foauth%2Fcallback
+  &scope=openid%20profile%20email
+  &state=A8z4Q…
+  &nonce=R1k…
+```
+
+Required parameters:
+
+- `response_type=code` — the only response type authn.sh supports.
+- `client_id` — Acme's `OauthApplication.client_id`.
+- `redirect_uri` — must **exactly match** one of the registered URIs. Strict matching per OAuth 2.1 BCP §1.4.2.
+- `scope` — space-separated. Each scope must be in the app's registered `scopes[]`.
+- `state` — CSRF token. Echoed back unchanged on the redirect. Acme generates and verifies.
+
+Optional parameters:
+
+- `nonce` — recommended for OIDC. Echoed into the `id_token` so Acme can detect replay.
+- `prompt` — `none` / `login` / `consent` / `select_account`. Controls re-auth and consent behaviour.
+- `code_challenge` + `code_challenge_method=S256` — required for `is_public: true` clients (PKCE).
+- `max_age` — request a re-auth if the user's session is older than this in seconds.
+
+Brian's browser follows the redirect.
+
+## Step 2 — authn.sh signs Brian in (or short-circuits)
+
+`/oauth/authorize` first checks: does Brian have an active session on `example.authn.sh`?
+
+- **No session, or `prompt=login` was passed.** authn.sh renders the regular `<SignIn />` UI. After successful sign-in, it falls through to step 3.
+- **Active session, no `prompt`.** Short-circuit to step 3.
+- **Active session, `prompt=none`.** Short-circuit to step 3. If the consent screen would normally render (see below), instead redirect back to `redirect_uri` with `error=consent_required` — `prompt=none` means "fail rather than show UI".
+
+The session is the **environment's existing FAPI session** — there's no separate "OAuth session". A user signed into `https://example.authn.sh` for any reason (your own product's sign-in, an earlier `/oauth/authorize`) is signed in for the OAuth flow too.
+
+## Step 3 — Consent
+
+authn.sh renders the consent screen with the data from `OauthApplication.consent_screen`:
+
+```
++----------------------------------------+
+| Acme Pages wants to access your        |
+| account on example.authn.sh            |
+|                                        |
+| It will be able to:                    |
+| ✓ Sign you in                          |
+| ✓ See your name and profile image      |
+| ✓ See your email address               |
+|                                        |
+| [Privacy] [Terms]                      |
+|                                        |
+| [Cancel]               [Allow]         |
++----------------------------------------+
+```
+
+The "It will be able to" list is generated from the requested `scope` against the scope registry's human-readable descriptions.
+
+**Consent is skipped** if a non-revoked `AuthorizationGrant` row already exists for `(Brian, oac_pub_AbC123)` covering **a superset** of the requested scopes. This is the "I already trust this app" path — the second sign-in skips the screen and goes straight to a fresh code. If new scopes are requested, the screen renders with a "Plus, new permissions:" diff section showing only the additions.
+
+If `prompt=consent` is passed, the screen always renders, even with an existing grant. Used for re-confirmation flows.
+
+Brian clicks **Allow**. authn.sh:
+
+- Upserts the `AuthorizationGrant` row — creates if new, expands `granted_scopes[]` if existing.
+- Generates a single-use `authorization_code` — opaque string, 10-minute TTL, bound to `(client_id, redirect_uri, code_challenge?)`.
+
+## Step 4 — authn.sh redirects back
+
+```
+302 Found
+Location: https://acme.example/oauth/callback
+  ?code=ac_5Z…
+  &state=A8z4Q…
+```
+
+Brian's browser follows the redirect to Acme's callback endpoint. Acme verifies that `state` matches what it issued — if not, abort.
+
+## Step 5 — Acme exchanges the code (server-to-server)
+
+```http
+POST /oauth/token HTTP/1.1
+Host: example.authn.sh
+Content-Type: application/x-www-form-urlencoded
+Authorization: Basic b2FjX3B1Yl9BYkMxMjM6b2FjX3NlY194eTcuLi4=
+
+grant_type=authorization_code
+&code=ac_5Z…
+&redirect_uri=https%3A%2F%2Facme.example%2Foauth%2Fcallback
+```
+
+The `Authorization: Basic` header carries `client_id:client_secret` (RFC 6749 §2.3.1). Public clients omit the `Authorization` header and pass `code_verifier` instead.
+
+authn.sh validates:
+
+- The `code` is unconsumed and not expired.
+- The `client_id` matches the code's binding.
+- The `redirect_uri` matches the code's binding (defense-in-depth — already validated on the authorize call).
+- The `code_verifier` hashes to the `code_challenge` if PKCE was used.
+
+On success:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "access_token": "at_eyJ…",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "rt_eyJ…",
+  "scope": "openid profile email",
+  "id_token": "eyJraWQiOi…"
+}
+```
+
+- `access_token` — bearer token for `/oauth/userinfo` and any custom resource servers. JWT, signed by the env's JWKS.
+- `refresh_token` — present iff `offline_access` was in the granted scopes. Long-lived; redeems for a fresh access token at `/oauth/token` with `grant_type=refresh_token`.
+- `id_token` — JWT. OIDC standard claims (`iss`, `sub`, `aud`, `exp`, `iat`, `nonce`) plus scope-filtered profile claims.
+
+## Step 6 — Acme calls /oauth/userinfo (optional)
+
+```http
+GET /oauth/userinfo HTTP/1.1
+Host: example.authn.sh
+Authorization: Bearer at_eyJ…
+```
+
+Response is the OIDC userinfo payload, scope-filtered:
+
+```json
+{
+  "sub": "user_01HKX9…",
+  "name": "Brian Adams",
+  "given_name": "Brian",
+  "family_name": "Adams",
+  "profile_image_url": "https://…",
+  "email": "brian@example.com",
+  "email_verified": true
+}
+```
+
+`phone` / `phone_verified` appear only if the `phone` scope was granted. The custom `organization:*` scopes attach `org_id`, `org_role`, `org_slug` claims on the same payload.
+
+## Refresh-token rotation
+
+Refresh tokens are **single-use** — every successful `refresh_token` grant rotates the refresh token and invalidates the old one. The response always includes a fresh `refresh_token`. If Acme attempts to redeem the same refresh token twice, the second call returns `400 invalid_grant` *and* revokes the `AuthorizationGrant` entirely (RFC 6749 §10.4-ish — refresh-token reuse is treated as a stolen-token signal).
+
+## Error responses
+
+The flow returns standard OAuth errors per RFC 6749 §4.1.2.1 — they come back as redirect-URI fragments / query strings on `/oauth/authorize` and as JSON bodies on `/oauth/token`.
+
+| Code | Cause |
+| --- | --- |
+| `invalid_request` | Missing required parameter. |
+| `invalid_client` | Unknown `client_id` or wrong `client_secret`. |
+| `invalid_grant` | Authorization code expired / consumed / mismatched binding. |
+| `invalid_scope` | Requested scope not in the app's registered `scopes[]`. |
+| `access_denied` | User clicked **Cancel** on the consent screen. |
+| `unsupported_response_type` | Anything other than `code`. |
+| `server_error` | Surprise. Includes a `trace_id` in the body for support escalation. |
+
+## Next
+
+- [PKCE for public clients](/concepts/oauth-provider/pkce/) — the variant for mobile / SPA / CLI apps.
+- [Discovery + JWKS](/concepts/oauth-provider/discovery/) — what's in `/.well-known/openid-configuration`.
+- [JWT templates](/concepts/jwt-templates/) — substitute a custom token shape for the default issued at `/oauth/token`.

--- a/src/content/docs/concepts/oauth-provider/discovery.md
+++ b/src/content/docs/concepts/oauth-provider/discovery.md
@@ -1,0 +1,157 @@
+---
+title: Discovery endpoint + JWKS
+description: The /.well-known/openid-configuration document authn.sh serves per env, what's in it, and why standard OIDC client libraries should always read from it rather than hard-coding endpoints.
+---
+
+OIDC requires IdPs to publish a **discovery document** so client libraries can resolve every endpoint, supported scope, and capability from a single URL. authn.sh serves the document at `/.well-known/openid-configuration` for every env. Available from v0.7.
+
+The matching **JWKS** (JSON Web Key Set) — the public keys client libraries use to verify `id_token` signatures — lives at `/.well-known/jwks.json`. This isn't new to v0.7; OAuth provider mode reuses the same JWKS the env's regular session tokens are signed with.
+
+## Discovery URL
+
+```
+https://<env_slug>.authn.sh/.well-known/openid-configuration
+```
+
+The full URL for the example env: `https://example.authn.sh/.well-known/openid-configuration`. For self-hosted envs with a custom domain (via the `<CustomDomain />` reference under the chart / CDK construct), substitute your domain.
+
+The response is **public** — no auth, CORS-open (`Access-Control-Allow-Origin: *`), cached for 5 minutes (`Cache-Control: public, max-age=300, stale-while-revalidate=86400`). The 5-minute window is short enough to absorb scope-registry changes; the stale-while-revalidate window keeps it responsive when something is rolled out at midnight.
+
+## Document shape
+
+```json
+{
+  "issuer": "https://example.authn.sh",
+  "authorization_endpoint": "https://example.authn.sh/oauth/authorize",
+  "token_endpoint": "https://example.authn.sh/oauth/token",
+  "userinfo_endpoint": "https://example.authn.sh/oauth/userinfo",
+  "introspection_endpoint": "https://example.authn.sh/oauth/token_info",
+  "jwks_uri": "https://example.authn.sh/.well-known/jwks.json",
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code", "refresh_token"],
+  "subject_types_supported": ["public"],
+  "id_token_signing_alg_values_supported": ["RS256", "ES256"],
+  "scopes_supported": [
+    "openid", "profile", "email", "phone", "offline_access",
+    "organization:read", "organization:write"
+  ],
+  "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post", "none"],
+  "code_challenge_methods_supported": ["S256"],
+  "claims_supported": [
+    "sub", "iss", "aud", "exp", "iat", "nonce",
+    "name", "given_name", "family_name", "profile_image_url", "locale",
+    "email", "email_verified",
+    "phone_number", "phone_number_verified",
+    "org_id", "org_role", "org_slug"
+  ]
+}
+```
+
+Two notes:
+
+- **`scopes_supported` is per-env, not per-application.** It lists every scope the environment can issue; an individual `OauthApplication` is restricted to a subset (its registered `scopes[]`).
+- **`code_challenge_methods_supported`** lists only `S256`. `plain` is accepted for `is_public: false` clients (legacy) but isn't advertised — advertising it would encourage public clients to pick it, which we don't want.
+
+## JWKS
+
+```
+GET https://example.authn.sh/.well-known/jwks.json
+```
+
+Returns the env's public signing keys:
+
+```json
+{
+  "keys": [
+    {
+      "kty": "RSA",
+      "kid": "kid_01HKX9Y…",
+      "use": "sig",
+      "alg": "RS256",
+      "n": "1bI6E…",
+      "e": "AQAB"
+    }
+  ]
+}
+```
+
+The same JWKS verifies:
+
+- Regular FAPI session tokens (existed since v0.1).
+- OAuth provider mode `id_token`s.
+- OAuth provider mode `access_token`s (when JWT-formatted — the default).
+
+There's one signing key per env at any given time. Rotation cycles a new `kid` into the JWKS, marks it primary for fresh tokens, and keeps the old key in the JWKS for the token-validity window so issued-but-not-expired tokens stay verifiable. The standard JWKS-caching client-library posture handles this automatically.
+
+For a deeper dive on the rotation mechanics, see [JWT claims](/reference/jwt-claims/#key-rotation).
+
+## Using discovery in client libraries
+
+The whole point of discovery is that clients don't hard-code your endpoints. Three concrete examples:
+
+### oidc-client-ts (browser SPA)
+
+```typescript
+import { UserManager } from 'oidc-client-ts';
+
+const manager = new UserManager({
+  authority: 'https://example.authn.sh',     // discovery URL = authority + /.well-known/openid-configuration
+  client_id: 'oac_pub_AbC123',
+  redirect_uri: 'https://acme.example/oauth/callback',
+  scope: 'openid profile email',
+  response_type: 'code',
+});
+```
+
+`oidc-client-ts` reads `https://example.authn.sh/.well-known/openid-configuration` on init and uses the endpoints it finds. Same library handles PKCE for you.
+
+### NextAuth (Node server + browser SPA)
+
+```javascript
+import NextAuth from 'next-auth';
+
+export default NextAuth({
+  providers: [
+    {
+      id: 'authn-sh',
+      name: 'Acme Authn',
+      type: 'oauth',
+      wellKnown: 'https://example.authn.sh/.well-known/openid-configuration',
+      clientId: process.env.AUTHN_CLIENT_ID,
+      clientSecret: process.env.AUTHN_CLIENT_SECRET,
+      authorization: { params: { scope: 'openid profile email' } },
+      idToken: true,
+      checks: ['pkce', 'state'],
+    },
+  ],
+});
+```
+
+The `wellKnown` field makes NextAuth resolve every endpoint from your discovery doc.
+
+### Python requests-oauthlib
+
+```python
+import requests
+from requests_oauthlib import OAuth2Session
+
+discovery = requests.get('https://example.authn.sh/.well-known/openid-configuration').json()
+
+oauth = OAuth2Session(
+    client_id='oac_pub_AbC123',
+    redirect_uri='https://acme.example/oauth/callback',
+    scope=['openid', 'profile', 'email'],
+)
+auth_url, state = oauth.authorization_url(discovery['authorization_endpoint'])
+```
+
+## Why not hard-code?
+
+Don't pin your client to authentication endpoints by hand. Discovery exists so that:
+
+- The env can add new scopes / claims and clients see them on the next document fetch.
+- Key rotation is invisible to clients (they re-fetch JWKS on signature-verification miss).
+- A custom-domain swap (`acme-internal.authn.sh` → `id.acme.example`) means flipping the `authority` URL once, not 12 hard-coded endpoints.
+- The env can quietly switch from RS256 to ES256 signing without breaking any client.
+
+Hard-coding is a deferred liability. Read the discovery doc.

--- a/src/content/docs/concepts/oauth-provider/overview.md
+++ b/src/content/docs/concepts/oauth-provider/overview.md
@@ -1,0 +1,79 @@
+---
+title: OAuth provider mode — overview
+description: Expose an authn.sh environment as an OAuth 2.0 / OIDC identity provider — let third-party apps sign their users in with your product.
+---
+
+In v0.7, an authn.sh environment can act as an **OAuth 2.0 / OIDC identity provider**. Third-party apps redirect their users to your env, the user signs in (or is already signed in), grants consent, and the third-party app receives an authorization code it can exchange for tokens. Standard RFC 6749 §4.1 + OIDC §3.1.2.1 authorization-code grant with PKCE for public clients, plus the matching token / userinfo / introspection / discovery endpoints.
+
+This unlocks two patterns:
+
+- **Sign in with `<your product>`** — your customers' end-users carry their existing identity in your product into third-party tools they integrate with. Same flow as "Sign in with Google".
+- **First-party integrations** — your own mobile / desktop / CLI apps treat your env as an IdP instead of bundling a publishable-key SDK. Lets you ship a unified consent surface for which scopes the app is allowed to read.
+
+If you're wiring a third-party IdP **into** authn.sh (so end-users can sign in with Google / Microsoft / a custom OIDC IdP), that's the inverse direction — see [Social sign-in](/guides/social-sign-in/) or the [custom-OIDC walkthrough](/guides/custom-oidc/).
+
+## The two new resources
+
+OAuth provider mode adds two resources to the environment:
+
+- **`OauthApplication`** (`oac_` prefix) — one row per registered third-party app. Carries `client_id`, write-only `client_secret`, `redirect_uris[]`, allowed `scopes[]`, an `is_public` flag for PKCE-only public clients (mobile / SPA), and a `consent_screen` config block.
+- **`AuthorizationGrant`** (`authgrant_` prefix) — one row per `(user, oauth_application)` pair, tracking which scopes the user has consented to. Created or updated on every successful authorization. Carries `granted_scopes[]`, `granted_at`, `revoked_at`. Users can revoke grants from the **Authorized apps** panel in `<UserProfile />`.
+
+The two resources fall out of the standard OAuth model: the application is the client registration; the grant is the per-user consent record that survives across sign-ins.
+
+## The five new endpoints
+
+All five live on the FAPI server, since they're browser-facing (or browser-initiated):
+
+| Endpoint | Spec | Purpose |
+| --- | --- | --- |
+| `GET /oauth/authorize` | RFC 6749 §4.1 + OIDC §3.1.2.1 | Authorization-code grant. Renders the consent screen, then redirects to `redirect_uri` with `code` + `state`. |
+| `POST /oauth/token` | RFC 6749 §4.1.3 + §6 | Exchanges `code` for `access_token` + `refresh_token` + `id_token`. Also services `refresh_token` grants. |
+| `POST /oauth/token_info` | RFC 7662 | Token introspection. Returns `{ active, sub, scope, exp, client_id, ... }`. |
+| `GET /oauth/userinfo` | OIDC §5.3 | Returns OIDC userinfo for the bearer token's user, scope-filtered. |
+| `GET /.well-known/openid-configuration` | OIDC Discovery §4 | OIDC discovery document for the environment. Static per-env. |
+
+The matching JWKS lives at the existing `/.well-known/jwks.json` — OAuth provider mode reuses the env's signing keys.
+
+## Browser flow at a glance
+
+```
+Third-party app                authn.sh env                       End-user browser
+      |                              |                                   |
+      |--- redirect ?client_id=oac_… ...---------------------->          |
+      |                              |  GET /oauth/authorize              |
+      |                              |  -> sign in if needed              |
+      |                              |  -> render consent screen          |
+      |                              |  <-- POST consent                  |
+      |                              |  -> generate authorization_code    |
+      |                              |  -> redirect to redirect_uri       |
+      |  <--- redirect ?code=… &state=… ---------------------- |          |
+      |                              |                                   |
+      |  POST /oauth/token (server-to-server)                             |
+      |  -> receive access_token + id_token + refresh_token               |
+```
+
+The user-facing portion happens entirely in their browser, hosted on your env's FAPI domain. The third-party app never sees the user's password / TOTP / passkey assertion — only the resulting code and tokens.
+
+## When to use it
+
+OAuth provider mode is the right choice when:
+
+- A third-party app wants to read user data on the user's behalf. Their access is bounded by the scopes the user consented to.
+- You're shipping a mobile / desktop / CLI app and don't want to bundle the publishable-key SDK (e.g. you want PKCE rather than a long-lived `__authn_client` cookie).
+- You're building a marketplace where third-party integrations need a "Sign in with your product" button.
+
+It's the **wrong** choice when:
+
+- You want a service-to-service integration with no user context. Use BAPI keys directly — they don't carry a user `sub`.
+- You want to embed your sign-in UI inline in a third-party app. The bundled SDK does that already; reach for OAuth provider mode only when you specifically want the browser-redirect contract.
+
+## What's not in v0.7
+
+A few standard OAuth surfaces ship later:
+
+- **Token revocation endpoint** (RFC 7009 `POST /oauth/revoke`) — not in v0.7. Revoke by deleting the `AuthorizationGrant` row.
+- **Device authorization grant** (RFC 8628) — not in v0.7. The codespath is reserved for v0.8.
+- **Client-credentials grant** — not in v0.7, and unlikely to ship — BAPI keys cover the equivalent surface without needing an OAuth round-trip.
+
+For the conceptual model of the resources, read on. For step-by-step registration of a third-party app, see [Registering an OAuth application](/concepts/oauth-provider/registering-an-application/).

--- a/src/content/docs/concepts/oauth-provider/pkce.md
+++ b/src/content/docs/concepts/oauth-provider/pkce.md
@@ -1,0 +1,116 @@
+---
+title: PKCE for public clients
+description: How authn.sh enforces RFC 7636 Proof Key for Code Exchange for any OauthApplication with is_public — code_challenge_methods, length bounds, error codes.
+---
+
+**PKCE** (RFC 7636) is the authorization-code grant variant for clients that can't safely store a `client_secret` — mobile apps, single-page apps, CLI tools. authn.sh implements PKCE per the spec and **requires** it for every `OauthApplication` with `is_public: true`. Available from v0.7.
+
+This page assumes you've read [the authorization-code flow](/concepts/oauth-provider/authorization-code-flow/) — PKCE is the same flow with two extra parameters.
+
+## The protocol in 30 seconds
+
+1. The app generates a high-entropy random string — the **`code_verifier`**.
+2. The app hashes it (SHA-256, base64url-no-pad) — the **`code_challenge`**.
+3. On `/oauth/authorize`, the app sends `code_challenge` + `code_challenge_method=S256`. The server binds them to the authorization code it issues.
+4. On `/oauth/token`, the app sends `code_verifier`. The server hashes it and compares against the stored `code_challenge`.
+
+The verifier never leaves the app's process. An attacker intercepting the authorization code can't redeem it without the verifier, so the redirect-URI hijacking attack PKCE was designed to mitigate is foreclosed.
+
+## Authorize call
+
+```
+https://example.authn.sh/oauth/authorize
+  ?response_type=code
+  &client_id=oac_pub_AbC123
+  &redirect_uri=acme-mobile%3A%2F%2Foauth%2Fcallback
+  &scope=openid%20profile%20email
+  &state=A8z4Q…
+  &code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+  &code_challenge_method=S256
+```
+
+- **`code_challenge`** — base64url-no-pad SHA-256 of the verifier. 43 chars exactly.
+- **`code_challenge_method`** — must be `S256`. `plain` is accepted only for `is_public: false` clients (a non-default escape hatch for legacy confidential clients) and rejected for public clients.
+
+If `code_challenge` is missing on a public client, `/oauth/authorize` rejects:
+
+```
+HTTP/1.1 302 Found
+Location: acme-mobile://oauth/callback
+  ?error=invalid_request
+  &error_description=code_challenge%20required%20for%20public%20clients
+  &state=A8z4Q…
+```
+
+## Token call
+
+```http
+POST /oauth/token HTTP/1.1
+Host: example.authn.sh
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code
+&client_id=oac_pub_AbC123
+&code=ac_5Z…
+&redirect_uri=acme-mobile%3A%2F%2Foauth%2Fcallback
+&code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+```
+
+Note: **no `Authorization: Basic` header**, and `client_id` is in the body (since there's no secret). The `code_verifier` is the original random string — the server SHA-256s it and compares against the stored `code_challenge`.
+
+Length bounds for the verifier (RFC 7636 §4.1):
+
+- Minimum 43 characters.
+- Maximum 128 characters.
+- Alphabet: `[A-Z][a-z][0-9]-._~` (unreserved per RFC 3986).
+
+Out-of-range verifiers fail with `invalid_request` before the hash comparison runs.
+
+## Failure modes
+
+| Cause | Response |
+| --- | --- |
+| Verifier hashes to a different challenge | `400 invalid_grant` |
+| Verifier missing on a code that was issued with a challenge | `400 invalid_grant` |
+| Verifier provided on a code that was issued without a challenge | `400 invalid_grant` |
+| Verifier outside the length / alphabet bounds | `400 invalid_request` |
+| `code_challenge_method=plain` on a public client | `302` redirect with `error=invalid_request` |
+
+The server never reveals which of these tripped — every PKCE failure looks like a generic `invalid_grant` from the caller's perspective. Detail lives in the env's audit log (BAPI `/v1/audit-log`) with the real reason.
+
+## Generating verifier + challenge
+
+For reference, this is the standard codepath:
+
+```javascript
+// In any Web-Crypto-capable runtime (browser / Node 19+ / Deno / Bun)
+const arr = new Uint8Array(32);
+crypto.getRandomValues(arr);
+const verifier = base64UrlNoPad(arr);                   // ~43 chars
+const hashed   = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+const challenge = base64UrlNoPad(new Uint8Array(hashed));
+```
+
+```python
+# Python 3.x
+import secrets, hashlib, base64
+
+verifier = secrets.token_urlsafe(32).rstrip('=')        # ~43 chars
+challenge = base64.urlsafe_b64encode(
+    hashlib.sha256(verifier.encode()).digest()
+).rstrip(b'=').decode()
+```
+
+Every OIDC client library worth its salt does this for you — `oidc-client-ts`, `appauth-android` / `-ios`, the `requests-oauthlib` Python lib. If you're rolling your own, the snippets above are correct.
+
+## Why authn.sh enforces this
+
+PKCE without `client_secret` is the modern best practice for any client where a secret can't be hidden:
+
+- Mobile apps — the secret would ship in the binary.
+- SPAs — the secret would ship in the JS bundle.
+- CLI tools — the secret would ship in the binary, or in a config file the user could read.
+
+For these, the `code_secret` provides no security benefit and creates a false sense of one. PKCE replaces it with a per-flow proof that the same process that started the flow is finishing it.
+
+For confidential server-to-server clients (Rails / Django / Laravel / Node backend doing OIDC sign-in), PKCE is **optional but recommended** — RFC 9700 (OAuth 2.0 Security BCP) recommends it for all clients. authn.sh accepts `code_challenge` + `code_verifier` from confidential clients and validates both when present.

--- a/src/content/docs/concepts/oauth-provider/registering-an-application.md
+++ b/src/content/docs/concepts/oauth-provider/registering-an-application.md
@@ -1,0 +1,122 @@
+---
+title: Registering an OauthApplication
+description: Wizard-driven registration for third-party OAuth clients — scopes, redirect URIs, public vs confidential clients, client-secret rotation.
+---
+
+Before a third-party app can call `/oauth/authorize`, an operator registers it as an `OauthApplication` row in the env's dashboard. This is a one-time setup per third-party client. Available from v0.7.
+
+The wizard lives at **Authentication → OAuth applications → New application** in the operator dashboard. The corresponding BAPI is `POST /v1/oauth-applications`.
+
+## Step 1 — Name and homepage
+
+```
+Name           Acme Pages
+Homepage URL   https://acme.example
+```
+
+The **Name** is rendered on the consent screen — pick what end-users should see ("Acme Pages", not "Acme internal SSO bridge"). It's immutable on PATCH only in the sense that changing it shows different text on subsequent consent screens; existing `AuthorizationGrant` rows are unaffected.
+
+The **Homepage URL** is the third-party app's marketing site — surfaced on the consent screen as a link the user can click before granting consent.
+
+## Step 2 — Public or confidential client
+
+```
+is_public      [ ] Yes — public client (PKCE-only, no client_secret)
+               [x] No  — confidential client (server-side, has a client_secret)
+```
+
+- **Confidential clients** (`is_public: false`) have a `client_secret` issued at create time. Used by server-side backends that can store the secret safely. The `POST /oauth/token` call must authenticate with the secret.
+- **Public clients** (`is_public: true`) have no `client_secret`. PKCE is **mandatory** — the authorize call without `code_challenge` is rejected. Used by mobile apps, SPAs, and CLI tools where the secret can't be hidden.
+
+The `is_public` field is **immutable** after create — flipping a public client to confidential (or vice versa) means deleting the row and re-registering with a fresh `client_id`, to force the third-party app to re-register on their end.
+
+## Step 3 — Redirect URIs
+
+```
+Redirect URIs
+  https://acme.example/oauth/callback
+  http://localhost:8080/oauth/callback        ← dev-only, see notes
+  acme-mobile://oauth/callback                ← mobile deep link
+```
+
+Multiple entries allowed. Each is matched **exactly** against the `redirect_uri` parameter on `/oauth/authorize` — no scheme / host / path wildcards, no query-string flexibility (we follow OAuth 2.1 BCP §1.4.2 strict matching).
+
+Three valid scheme classes:
+
+- `https://…` — the production path. Hosts on `localhost` are allowed without TLS (`http://localhost:8080/…`) as an explicit dev-mode escape hatch. Other plain-HTTP hosts are rejected (`422 redirect_uri_insecure`).
+- `<custom>://…` — mobile deep links, e.g. `acme-mobile://`. The scheme must contain a hyphen or dot to disambiguate from `http`/`https`.
+- The Native loopback pattern `http://127.0.0.1:0/…` is also accepted for CLI tools that open a local listener on an ephemeral port.
+
+## Step 4 — Scopes
+
+```
+Scopes available to this app:
+  [x] openid                  OIDC sign-in (required to issue an id_token)
+  [x] profile                 name, profile_image_url, locale
+  [x] email                   email_address, email_verified
+  [ ] phone                   phone_number, phone_verified
+  [ ] offline_access          issue refresh_token (long-lived sessions)
+  [ ] organization:read       memberships + active org snapshot
+  [ ] organization:write      modify memberships on behalf of the user
+```
+
+Standard OIDC scopes (`openid`, `profile`, `email`, `phone`) plus a few authn.sh-specific ones (`offline_access`, `organization:read`, `organization:write`). The full list is in the **scopes** registry — `GET /v1/oauth-scopes` on the BAPI returns it.
+
+Each scope ticked here is **available** to request — the app can ask for any subset on a given authorization, but never more than what's been ticked. Users still choose to grant or deny on the consent screen.
+
+Custom per-environment scopes (`acme:projects.read`) are configured separately under **Authentication → OAuth scopes** — they live in their own table and can be referenced by name.
+
+## Step 5 — Consent screen config
+
+```
+Consent screen:
+  Description:  Acme Pages is a static-site generator that publishes from your authn.sh-authenticated content.
+  Logo URL:     https://acme.example/logo.png
+  Privacy URL:  https://acme.example/privacy
+  Terms URL:    https://acme.example/terms
+```
+
+All four fields are rendered on the consent screen. The **Description** lets the user understand what the app does without leaving the page; **Privacy** and **Terms** are required for any app that requests `email` or higher-privilege scopes.
+
+## After create
+
+The wizard returns the registration result:
+
+```json
+{
+  "object": "oauth_application",
+  "id": "oac_01J7Z…",
+  "client_id": "oac_pub_AbC123_…",
+  "client_secret": "oac_sec_xy7…",
+  "is_public": false,
+  "redirect_uris": ["https://acme.example/oauth/callback"],
+  "scopes": ["openid", "profile", "email"],
+  "...": "..."
+}
+```
+
+The `client_secret` is **shown exactly once** on the create response. Subsequent GETs replace it with `null`. Lose it → call `POST /v1/oauth-applications/{id}/rotate-secret` to mint a fresh one (and update the third-party app to match).
+
+The discovery URL the third-party app's developer plugs in is:
+
+```
+https://<env_slug>.authn.sh/.well-known/openid-configuration
+```
+
+That single URL gets them the issuer, authorize / token / userinfo / JWKS endpoints, the supported scopes / grant types / response types, and the PKCE methods. From there their OIDC library handles the rest.
+
+## Client-secret rotation
+
+```
+POST /v1/oauth-applications/{id}/rotate-secret
+→ 200 OK
+{ "client_secret": "oac_sec_NEW…" }
+```
+
+Issues a fresh secret and **immediately** invalidates the old one — there's no overlap window. Plan accordingly: deploy the new secret to the third-party app's server *after* you have it, *before* the next sign-in attempt. For zero-downtime rotation, register a second `OauthApplication` row alongside the first, switch the app over, then delete the old row.
+
+## Editing afterwards
+
+`PATCH /v1/oauth-applications/{id}` accepts updates to `name`, `homepage_url`, `redirect_uris`, `scopes`, and the four consent-screen fields. `is_public` and `client_id` are immutable.
+
+Deleting a row (`DELETE`) revokes every issued `AuthorizationGrant` and refuses subsequent `/oauth/authorize` calls with `401 invalid_client`. Grants are hard-deleted; the audit-trail of who-granted-what is preserved through webhook events (`oauthApplication.deleted`, `authorizationGrant.revoked`).

--- a/src/content/docs/concepts/webhooks.md
+++ b/src/content/docs/concepts/webhooks.md
@@ -150,4 +150,23 @@ scimUser.deprovisioned
 - `scimToken.*` → `ScimToken`. The plaintext `token` is **never** in the payload — only the `prefix`. Captures token issuance / revocation for audit handlers.
 - `scimUser.*` → `{ user: User, enterprise_connection_id, organization_id }`. The triple carries the connection that drove the SCIM operation plus the scoping org, so audit handlers can route without a follow-up lookup.
 
+### v0.7
+
+```
+jwtTemplate.created
+jwtTemplate.updated
+jwtTemplate.deleted
+oauthApplication.created
+oauthApplication.updated
+oauthApplication.deleted
+authorizationGrant.granted
+authorizationGrant.revoked
+```
+
+`data` carries:
+
+- `jwtTemplate.*` → `JwtTemplate`. The write-only `custom_signing_key` is **never** in the payload — same write-only contract as the GET responses.
+- `oauthApplication.*` → `OauthApplication`. The write-only `client_secret` is **never** in the payload — even on `oauthApplication.created`, the only place plaintext is surfaced is the BAPI create response.
+- `authorizationGrant.*` → `AuthorizationGrant`. Fires when a user first consents (`granted`) and on revocation (`revoked` — both user-driven via `<UserProfile />` and operator-driven via BAPI). `meta.surface` distinguishes `"user"` from `"operator"`.
+
 The live list is published via `GET /v1/event-types` against the BAPI.

--- a/src/content/docs/guides/scim/admin-bapi.md
+++ b/src/content/docs/guides/scim/admin-bapi.md
@@ -1,0 +1,180 @@
+---
+title: SCIM admin via BAPI
+description: Issue, list, and revoke SCIM tokens programmatically from your backend using $authn->organizations()->scimTokens() and the matching JS SDK call.
+---
+
+In v0.6, SCIM token issuance was per-org and FAPI-only — operators provisioned tokens through `<OrganizationProfile />` in the customer-facing UI. v0.7 adds the **BAPI mirror** so operators can issue and rotate SCIM tokens server-side without going through the FAPI surface. Available from v0.7. Closes the v0.6 carryover.
+
+This walkthrough covers the BAPI flow. For the customer-facing flow through `<OrganizationProfile />`, see the per-IdP [SCIM walkthroughs](/guides/scim/okta/).
+
+## When to use the BAPI path
+
+- **Onboarding automation.** You're scripting a customer-org setup and want to mint a SCIM token in the same migration that creates the org, the verified domain, and the enterprise connection.
+- **Token rotation.** You're rotating SCIM tokens on a schedule (every 90 days, say) and want a server-side cron rather than a human clicking through the UI.
+- **Multi-org reconciliation.** You want one daily report that lists every active SCIM token across every org with their last-used timestamps.
+- **Operator backstop.** Your customer org's admin lost their token and can't get back in to issue a fresh one — operator support mints a replacement via BAPI.
+
+## The endpoints
+
+The full set mirrors the v0.6 FAPI surface, scoped to an org:
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/v1/organizations/{org_id}/scim/endpoint` | Read the SCIM endpoint URL the IdP admin will paste into their provisioning config. |
+| `GET` | `/v1/organizations/{org_id}/scim/tokens` | List active + revoked `ScimToken` rows. Plaintext never returned. |
+| `POST` | `/v1/organizations/{org_id}/scim/tokens` | Issue a fresh SCIM token. **Plaintext returned exactly once on this response.** |
+| `POST` | `/v1/organizations/{org_id}/scim/tokens/{id}/revoke` | Revoke. Subsequent SCIM requests with the token return `401`. |
+| `GET` | `/v1/organizations/{org_id}/scim/attribute-mappings` | Read the per-org override (returns platform defaults when no override is set). |
+| `PUT` | `/v1/organizations/{org_id}/scim/attribute-mappings` | Replace the override. Empty `mapping: {}` reverts to defaults. |
+
+All six are BAPI keys — server-side, secret-key authenticated, never browser-exposed. No FAPI capability gate or permission check (the BAPI key is the auth boundary).
+
+## PHP — `$authn->organizations()->scimTokens()`
+
+The `sdk-php` `OrganizationsManager` exposes a `scimTokens` sub-manager:
+
+```php
+use Authnsh\Authn\AuthnClient;
+
+$authn = new AuthnClient(['secret_key' => env('AUTHN_SECRET_KEY')]);
+
+// Issue a fresh token for org_abc
+$result = $authn->organizations()->scimTokens()->create('org_abc', [
+    'description' => 'Issued by ops cron 2026-05-12',
+]);
+
+// Plaintext is on the create response — save it immediately.
+echo $result->token;            // "scim_5Z4Q9k…" — never appears again
+echo $result->prefix;           // "scim_5Z4Q…" — appears on every subsequent GET
+echo $result->id;               // "scimtkn_01J7Z…"
+
+// List tokens
+foreach ($authn->organizations()->scimTokens()->list('org_abc') as $row) {
+    printf("%s — prefix=%s revoked_at=%s\n", $row->id, $row->prefix, $row->revoked_at ?? 'never');
+}
+
+// Revoke
+$authn->organizations()->scimTokens()->revoke('org_abc', 'scimtkn_01J7Z…');
+```
+
+The matching `AttributeMappings` sub-manager:
+
+```php
+// Read (returns defaults when no override is set)
+$mapping = $authn->organizations()->scimAttributeMappings()->get('org_abc');
+
+// Replace
+$authn->organizations()->scimAttributeMappings()->put('org_abc', [
+    'mapping' => [
+        'userName' => 'email_address',
+        'name.givenName' => 'first_name',
+        'name.familyName' => 'last_name',
+        'externalId' => 'external_id',
+        'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department'
+            => 'public_metadata.department',
+    ],
+]);
+
+// Reset to platform defaults
+$authn->organizations()->scimAttributeMappings()->put('org_abc', ['mapping' => []]);
+```
+
+## JavaScript — `authn.organizations.scimTokens`
+
+The matching shape on `@authn-sh/sdk-js`:
+
+```typescript
+import { Authn } from '@authn-sh/sdk-js';
+
+const authn = new Authn({ secretKey: process.env.AUTHN_SECRET_KEY! });
+
+// Issue
+const { token, prefix, id } = await authn.organizations.scimTokens.create('org_abc', {
+  description: 'Issued by ops cron 2026-05-12',
+});
+
+console.log(token);  // "scim_5Z4Q9k…" — save now
+
+// List
+const rows = await authn.organizations.scimTokens.list('org_abc');
+
+// Revoke
+await authn.organizations.scimTokens.revoke('org_abc', id);
+
+// Read endpoint URL (for surfacing in your dashboard or in a customer-facing email)
+const { endpoint_url } = await authn.organizations.scimEndpoint.get('org_abc');
+```
+
+## Onboarding flow
+
+The full automate-from-scratch flow for a new B2B customer:
+
+```php
+// 1. Create the org
+$org = $authn->organizations()->create(['name' => 'Acme Inc.', 'slug' => 'acme']);
+
+// 2. Add and verify the domain
+$domain = $authn->organizations()->domains()->create($org->id, [
+    'name' => 'acme.example',
+    'enrollment_mode' => 'automatic_invitation',
+]);
+// (then operator-side prompt to add the DNS TXT and call /verify)
+
+// 3. Add the enterprise SSO connection (Okta in this example)
+$conn = $authn->enterpriseConnections()->create([
+    'protocol' => 'saml',
+    'organization_id' => $org->id,
+    'name' => 'Acme Okta',
+    'domains' => ['acme.example'],
+    'saml_idp_entity_id' => $oktaMetadata->entity_id,
+    'saml_sso_url' => $oktaMetadata->sso_url,
+    'saml_idp_certificate' => $oktaMetadata->certificate,
+]);
+
+// 4. Mint the SCIM token
+$scim = $authn->organizations()->scimTokens()->create($org->id, [
+    'description' => 'Onboarding cron, ticket #4711',
+]);
+
+// 5. Email the IdP admin everything they need
+Mail::to($adminEmail)->send(new ScimOnboardingMail([
+    'org_name'        => $org->name,
+    'scim_endpoint'   => $authn->organizations()->scimEndpoint()->get($org->id)->endpoint_url,
+    'scim_token'      => $scim->token,  // ← only chance — survives only inside this request
+    'okta_app_id'     => $oktaApp->id,
+]));
+```
+
+The `scim_token` plaintext lives **only** in the response of the `create` call. Save it immediately — even your audit log shouldn't store it (store the `prefix` instead). The email handler above includes it in transit only.
+
+## Rotation cron
+
+```php
+// Run weekly. Rotates any token issued more than 90 days ago.
+foreach (Organization::active()->cursor() as $org) {
+    $tokens = $authn->organizations()->scimTokens()->list($org->authn_id);
+    foreach ($tokens as $row) {
+        if ($row->revoked_at !== null) continue;
+        if (now()->diffInDays($row->created_at_carbon) < 90) continue;
+
+        // Mint replacement, distribute it, then revoke the old one.
+        $replacement = $authn->organizations()->scimTokens()->create($org->authn_id, [
+            'description' => "Auto-rotation, replaces {$row->id}",
+        ]);
+
+        ScimRotationMail::dispatch($org, $replacement->token);
+
+        $authn->organizations()->scimTokens()->revoke($org->authn_id, $row->id);
+    }
+}
+```
+
+There's no overlap window — the IdP's provisioning config must be updated to the new token before you revoke the old one. The typical pattern is to mint the replacement, send it to the customer with a deadline (e.g. "rotate within 7 days"), and only revoke the old token after the deadline.
+
+## Webhook events
+
+The BAPI surface fires the same `scimToken.issued` and `scimToken.revoked` events as the FAPI surface. The plaintext token is **never** in the event payload — only the `prefix`. Audit handlers can distinguish BAPI-issued tokens from FAPI-issued ones via the `event.meta.surface` field (`"bapi"` vs `"fapi"`).
+
+## Permissions
+
+There's no permission gate — the BAPI key is the auth boundary. Anyone with the env's BAPI secret can issue, list, and revoke SCIM tokens for any org in the env. If you want per-ops-engineer audit trails, distribute scoped BAPI keys (`POST /v1/api-keys` with `restricted_to_actions: ['organizations.scim_tokens.*']`) rather than sharing the env's primary key.

--- a/src/content/docs/reference/rest.md
+++ b/src/content/docs/reference/rest.md
@@ -16,6 +16,79 @@ The REST reference is generated from the [`authn-sh/openapi`](https://github.com
 - Errors follow the envelope `{ "errors": [{ "code", "message", "long_message", "meta" }], "trace_id" }`.
 - Pagination is opaque cursor-based: `?cursor=<token>&limit=<n>`. Responses include `meta.next_cursor` when more rows exist.
 
+## v0.7 endpoints (BAPI)
+
+### JWT templates {#jwt-templates-bapi}
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/v1/jwt-templates` | List every `JwtTemplate` on the environment. |
+| `POST` | `/v1/jwt-templates` | Create. `name` must be unique per env. `custom_signing_key` is write-only. |
+| `GET` | `/v1/jwt-templates/{id}` | Fetch one. `custom_signing_key` is never returned. |
+| `PATCH` | `/v1/jwt-templates/{id}` | Update name, claims, lifetime, allowed_clock_skew, signing_algorithm. Send `null` on `custom_signing_key` to clear. |
+| `DELETE` | `/v1/jwt-templates/{id}` | Hard-delete. SDK calls to `getToken({ template: <name> })` thereafter fail with `404`. |
+| `POST` | `/v1/users/{user_id}/jwt-templates/{name}/tokens` | Mint a token for a specific user — backend-issuance path with no browser session. |
+
+### OAuth applications
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/v1/oauth-applications` | List every `OauthApplication` on the environment. |
+| `POST` | `/v1/oauth-applications` | Register a third-party app. **`client_secret` is returned exactly once on this response.** `is_public` is immutable. |
+| `GET` | `/v1/oauth-applications/{id}` | Fetch one. `client_secret` is never included. |
+| `PATCH` | `/v1/oauth-applications/{id}` | Update name, homepage_url, redirect_uris, scopes, consent_screen. `is_public` and `client_id` are immutable. |
+| `DELETE` | `/v1/oauth-applications/{id}` | Hard-delete. Revokes every linked `AuthorizationGrant`. |
+| `POST` | `/v1/oauth-applications/{id}/rotate-secret` | Mint a fresh `client_secret`. **No overlap window — old secret is invalidated immediately.** |
+| `GET` | `/v1/oauth-applications/{id}/authorization-grants` | List every `AuthorizationGrant` for this app (operator view across all users). |
+| `DELETE` | `/v1/oauth-applications/{id}/authorization-grants/{grant_id}` | Revoke a specific grant (operator unlink). |
+
+### BAPI SCIM admin
+
+The v0.6 deferral — operator-side mirror of the per-org FAPI SCIM surface.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/v1/organizations/{org_id}/scim/endpoint` | Read the SCIM endpoint URL for the org. |
+| `GET` | `/v1/organizations/{org_id}/scim/tokens` | List active + revoked `ScimToken` rows. Plaintext never returned. |
+| `POST` | `/v1/organizations/{org_id}/scim/tokens` | Issue a SCIM token. **Plaintext returned exactly once.** |
+| `POST` | `/v1/organizations/{org_id}/scim/tokens/{id}/revoke` | Revoke. |
+| `GET` | `/v1/organizations/{org_id}/scim/attribute-mappings` | Read the per-org override (or defaults when no override is set). |
+| `PUT` | `/v1/organizations/{org_id}/scim/attribute-mappings` | Replace the override. Empty `mapping: {}` reverts to defaults. |
+
+### Enterprise accounts (admin)
+
+Spec backfill — `EnterpriseAccount` listing / get / delete were live since v0.6 but not in the OpenAPI bundle.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/v1/enterprise-accounts` | List every `EnterpriseAccount` on the env (filter by `user_id` / `enterprise_connection_id`). |
+| `GET` | `/v1/enterprise-accounts/{id}` | Fetch one. |
+| `DELETE` | `/v1/enterprise-accounts/{id}` | Admin unlink — preserves the underlying `User`. |
+
+## v0.7 endpoints (FAPI)
+
+### OAuth provider mode
+
+All five are hosted on the FAPI server (the env's customer-facing origin). None of them live under `/v1/client/...` — they're top-level OAuth-spec endpoints.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/oauth/authorize` | Authorization-code grant entry point. Renders sign-in + consent, then `302` to `redirect_uri`. RFC 6749 §4.1 + OIDC §3.1.2.1. |
+| `POST` | `/oauth/token` | Exchange `authorization_code` for tokens, or refresh-token grant. `client_secret_basic` / `client_secret_post` / `none` auth (per `is_public`). |
+| `POST` | `/oauth/token_info` | Token introspection per RFC 7662. |
+| `GET` | `/oauth/userinfo` | OIDC userinfo. Scope-filtered claims. Bearer-token auth. |
+| `GET` | `/.well-known/openid-configuration` | OIDC discovery document. Public, CORS-open, cached 5 minutes. |
+
+### User-scoped authorization grants
+
+The signed-in user's view of their granted apps — backs `<UserProfile />`'s **Authorized apps** section.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/v1/me/oauth-authorization-grants` | List the user's active `AuthorizationGrant` rows. |
+| `GET` | `/v1/me/oauth-authorization-grants/{id}` | Fetch one. |
+| `DELETE` | `/v1/me/oauth-authorization-grants/{id}` | Revoke — hard-deletes the row. Subsequent third-party-app refresh calls return `401 invalid_grant`. |
+
 ## v0.6 endpoints (BAPI)
 
 ### Enterprise SSO (instance-wide)

--- a/src/content/docs/sdk/react/components/user-profile.md
+++ b/src/content/docs/sdk/react/components/user-profile.md
@@ -22,6 +22,7 @@ Renders a multi-section panel:
 - **Account** — name, profile image, primary email / phone selection.
 - **Security** — password management, passkey enrollment list, TOTP enrollment, backup codes, active sessions.
 - **Connected accounts** — OAuth provider links (add / remove).
+- **Authorized apps** — third-party `OauthApplication`s the user has granted access to (revoke / view granted scopes). New in v0.7. See [Authorized apps](#authorized-apps) below.
 - **Phone numbers** — add / verify / set primary / reserve-for-MFA.
 - **Emails** — add / verify / set primary.
 - **Organizations** — when the environment has Organizations enabled, the user's memberships list.
@@ -57,6 +58,24 @@ For app-specific account settings (e.g. "Notifications", "Billing") you want to 
 ```
 
 `label`, `url`, `labelIcon` define the sidebar entry. The children render in the right-hand pane when the user navigates to that section. The component handles the routing — your inner component doesn't need to know how it's mounted.
+
+## Authorized apps
+
+The **Authorized apps** section lists every third-party `OauthApplication` the user has granted scopes to via [OAuth provider mode](/concepts/oauth-provider/overview/). Each entry shows:
+
+- The application name and homepage URL (from `OauthApplication.consent_screen`).
+- The granted scopes (e.g. `openid`, `profile`, `email`, `offline_access`) with their human-readable descriptions.
+- When the grant was first established (`granted_at`) and the last time the app exchanged a refresh token (`last_used_at`).
+- A **Revoke access** button that deletes the underlying `AuthorizationGrant` row. The next call from that app to `/oauth/userinfo` or any refresh-token exchange returns `401 invalid_grant`, forcing the third-party app to re-prompt for consent on its next sign-in.
+
+The section auto-hides when:
+
+- The environment has no `OauthApplication` rows configured, **or**
+- The signed-in user has zero non-revoked `AuthorizationGrant` rows.
+
+Revocation is hard-delete on the row — there's no "pause" state. To grant access back, the user goes through the third-party app's sign-in flow again and re-consents.
+
+Under the hood this reads `GET /v1/me/oauth-authorization-grants` and writes `DELETE /v1/me/oauth-authorization-grants/{id}`. Wire this up yourself with the `<UserProfile.AuthorizedApps />` subcomponent if you want to relocate it (e.g. surface it on a dedicated `/integrations` page rather than inside the account-settings flow).
 
 ## Composition
 


### PR DESCRIPTION
## Summary

- New top-level **OAuth provider mode** section under Concepts: Overview, Registering an `OauthApplication`, Authorization-code grant flow (RFC 6749 §4.1 + OIDC §3.1.2.1 trace, refresh-token rotation, error-code matrix), PKCE for public clients (mandatory `S256`, length / alphabet bounds, JS + Python generator snippets), Discovery endpoint + JWKS (full document shape, `oidc-client-ts` / NextAuth / `requests-oauthlib` consumer recipes).
- **Concepts → JWT templates** — the `JwtTemplate` resource, Liquid placeholder reference (`user.*` minus `private_metadata`, `session.*`, `session.active_organization*`, `org_memberships[]`, built-in filters + `date_unix` / `urlencode`), `60..86400` lifetime + `0..60` clock-skew bounds, RS256 / ES256 / HS256 signing with optional write-only `custom_signing_key` (per-template JWKS at `/.well-known/jwt-template-jwks/<name>.json`), SDK `getToken({ template })` consumption, BAPI `/v1/users/{user_id}/jwt-templates/{name}/tokens` backend-issuance path.
- **Guides → SCIM admin via BAPI** — the v0.6 carryover now live: `$authn->organizations()->scimTokens()` create / list / revoke with plaintext-once contract, `ScimAttributeMapping` `PUT` override, full onboarding worked example, 90-day rotation cron pattern, `event.meta.surface` BAPI / FAPI distinction.
- **`<UserProfile />` Authorized apps** — third-party `OauthApplication` consent-grant list with granted-scope view, `granted_at` / `last_used_at`, hard-delete-on-revoke contract, `<UserProfile.AuthorizedApps />` subcomponent for relocation onto a dedicated `/integrations` page.
- Webhooks event catalogue extended with the eight v0.7 events (`jwtTemplate.*` with `custom_signing_key` stripped; `oauthApplication.*` with `client_secret` stripped; `authorizationGrant.granted` / `.revoked` with `meta.surface` user-vs-operator).
- REST reference extended with v0.7 BAPI tables (`/v1/jwt-templates` CRUD + backend-issuance path; `/v1/oauth-applications` CRUD + `/rotate-secret` + per-app `authorization-grants` admin view; BAPI SCIM admin mirror closing the v0.6 deferral; `/v1/enterprise-accounts` spec backfill) and FAPI tables (`/oauth/authorize`, `/oauth/token`, `/oauth/token_info`, `/oauth/userinfo`, `/.well-known/openid-configuration`, `/v1/me/oauth-authorization-grants`).
- Sidebar reorganized: new top-level **OAuth provider mode** section; **Concepts** adds JWT templates; **SCIM 2.0** adds the BAPI walkthrough.

## Test plan

- [x] `npm run build` — astro build passes; 58 pages rendered (up from 51 in v0.6).
- [x] Six new pages route under the sitemap: `/concepts/oauth-provider/{overview,registering-an-application,authorization-code-flow,pkce,discovery}/`, `/concepts/jwt-templates/`, `/guides/scim/admin-bapi/`.
- [x] No broken internal links surfaced by the build.
- [x] CHANGELOG entry follows the existing v0.6 format.

Closes #17